### PR TITLE
Extend for flight testing uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ with immediate feedback.
 - open the `testing_notebook.ipynb` file
 
 ### TODO list ###
+- plot ground truth if found in log
+- create a public index page: sortable & filterable by SW version, HW, airframe,
+  success/failure, flight duration, ...
+  -> add a checkbox 'public' to upload form
+- Google Maps seems to have some problems (initialization, scaling and zooming
+  issues). This is bokeh
 - maximum upload size is currently limited to 100MB. This requires a bokeh
   setting.
 - add SSL

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -26,8 +26,19 @@ class DBData:
         self.description = ''
         self.feedback = ''
         self.type = 'personal'
-        self.weather = ''
+        self.wind_speed = -1
         self.rating = ''
+        self.video_url = ''
+
+    def windSpeedStr(self):
+        return {0: 'Calm', 5: 'Breeze', 8: 'Gale', 10: 'Storm'}.get(self.wind_speed, '')
+
+    def ratingStr(self):
+        return {'crash_pilot': 'Crashed (Pilot mistake)',
+                'crash_sw_hw': 'Crashed (Software or Hardware issue)',
+                'unsatisfactory': 'Unsatisfactory',
+                'good': 'Good',
+                'great': 'Great!'}.get(self.rating, '')
 
 
 def add_fragment(plots, name, display_name = None):
@@ -106,13 +117,16 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
     h, m = divmod(m, 60)
     table_text.append(('Logging duration', '{:d}:{:02d}:{:02d}'.format( h, m, s)))
 
-    # weather, rating, feedback
-    if len(db_data.weather) > 0:
-        table_text.append(('Weather', db_data.weather))
+    # Wind speed, rating, feedback
+    if db_data.wind_speed >= 0:
+        table_text.append(('Wind Speed', db_data.windSpeedStr()))
     if len(db_data.rating) > 0:
-        table_text.append(('Flight Rating', db_data.rating))
+        table_text.append(('Flight Rating', db_data.ratingStr()))
     if len(db_data.feedback) > 0:
         table_text.append(('Feedback', db_data.feedback.replace('\n', '<br/>')))
+    if len(db_data.video_url) > 0:
+        table_text.append(('Video', '<a href="'+db_data.video_url+
+            '" target="_blank">'+db_data.video_url+'</a>'))
 
     # generate the table
     divs_text = '<table>' + ''.join(['<tr><td class="left">'+a+

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -19,6 +19,17 @@ from config import *
 from plotting import *
 
 
+class DBData:
+    """ simple class that contains information from the DB entry of a single
+    log file """
+    def __init__(self):
+        self.description = ''
+        self.feedback = ''
+        self.type = 'personal'
+        self.weather = ''
+        self.rating = ''
+
+
 def add_fragment(plots, name, display_name = None):
     """ add a navigation anchor """
     global plot_width
@@ -29,7 +40,7 @@ def add_fragment(plots, name, display_name = None):
         width = int(plot_width*0.9)))
 
 
-def generate_plots(ulog, px4_ulog, flight_mode_changes, log_description):
+def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
     """ create a list of bokeh plots (and widgets) to show """
 
     plots = []
@@ -41,8 +52,8 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, log_description):
         sys_name = cgi.escape(ulog.msg_info_dict['sys_name']) + ' '
     div = Div(text="<h1>"+sys_name + px4_ulog.get_mav_type()+"</h1>", width=int(plot_width*0.9))
     header_divs = [ div ]
-    if log_description != '':
-        div_descr = Div(text="<h4>"+log_description+"</h4>", width=int(plot_width*0.9))
+    if db_data.description != '':
+        div_descr = Div(text="<h4>"+db_data.description+"</h4>", width=int(plot_width*0.9))
         header_divs.append(div_descr)
 
     # airframe
@@ -94,6 +105,14 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, log_description):
     m, s = divmod(int((ulog.last_timestamp - ulog.start_timestamp)/1e6), 60)
     h, m = divmod(m, 60)
     table_text.append(('Logging duration', '{:d}:{:02d}:{:02d}'.format( h, m, s)))
+
+    # weather, rating, feedback
+    if len(db_data.weather) > 0:
+        table_text.append(('Weather', db_data.weather))
+    if len(db_data.rating) > 0:
+        table_text.append(('Flight Rating', db_data.rating))
+    if len(db_data.feedback) > 0:
+        table_text.append(('Feedback', db_data.feedback.replace('\n', '<br/>')))
 
     # generate the table
     divs_text = '<table>' + ''.join(['<tr><td class="left">'+a+

--- a/plot_app/main.py
+++ b/plot_app/main.py
@@ -92,14 +92,16 @@ if error_message == '':
     try:
         con = sqlite3.connect(get_db_filename(), detect_types=sqlite3.PARSE_DECLTYPES)
         cur = con.cursor()
-        cur.execute('select Description, Feedback, Type, Weather, Rating from Logs where Id = ?', [log_id])
+        cur.execute('select Description, Feedback, Type, WindSpeed, Rating, VideoUrl '
+                'from Logs where Id = ?', [log_id])
         db_tuple = cur.fetchone()
         if db_tuple != None:
             db_data.description = db_tuple[0]
             db_data.feedback = db_tuple[1]
             db_data.type = db_tuple[2]
-            db_data.weather = db_tuple[3]
+            db_data.wind_speed = db_tuple[3]
             db_data.rating = db_tuple[4]
+            db_data.video_url = db_tuple[5]
         cur.close()
         con.close()
     except:

--- a/plot_app/main.py
+++ b/plot_app/main.py
@@ -12,7 +12,7 @@ from pyulog.px4 import *
 
 from helper import *
 from config import *
-from configured_plots import generate_plots
+from configured_plots import generate_plots, DBData
 
 
 
@@ -87,22 +87,26 @@ if error_message == '':
         flight_mode_changes = []
 
 
-    # read the description from DB
-    log_description = ''
+    # read the data from DB
+    db_data = DBData()
     try:
         con = sqlite3.connect(get_db_filename(), detect_types=sqlite3.PARSE_DECLTYPES)
         cur = con.cursor()
-        cur.execute('select Description from Logs where Id = ?', [log_id])
+        cur.execute('select Description, Feedback, Type, Weather, Rating from Logs where Id = ?', [log_id])
         db_tuple = cur.fetchone()
         if db_tuple != None:
-            log_description = db_tuple[0]
+            db_data.description = db_tuple[0]
+            db_data.feedback = db_tuple[1]
+            db_data.type = db_tuple[2]
+            db_data.weather = db_tuple[3]
+            db_data.rating = db_tuple[4]
         cur.close()
         con.close()
     except:
         print("DB access failed:", sys.exc_info()[0], sys.exc_info()[1])
 
 
-    plots = generate_plots(ulog, px4_ulog, flight_mode_changes, log_description)
+    plots = generate_plots(ulog, px4_ulog, flight_mode_changes, db_data)
 
     title = 'Flight Review - '+px4_ulog.get_mav_type()
 

--- a/plot_app/static/css/main.css
+++ b/plot_app/static/css/main.css
@@ -53,7 +53,9 @@ label {
 }
 
 table.spaced {
+	/* upload page */
 	margin: 16px 0;
+	width: 650px;
 }
 table.spaced tbody {
 	background: #f9f9f9;

--- a/setup_db.py
+++ b/setup_db.py
@@ -23,17 +23,17 @@ with con:
     if len(columns) == 0:
         cur.execute("CREATE TABLE Logs(Id TEXT, Title TEXT, Description TEXT, "
                 "OriginalFilename TEXT, Date TIMESTAMP, AllowForAnalysis INTEGER, "
-                "Obfuscated INTEGER, Source TEXT, Email TEXT, Weather TEXT, "
-                "Rating TEXT, Feedback TEXT, Type TEXT)")
+                "Obfuscated INTEGER, Source TEXT, Email TEXT, WindSpeed INT, "
+                "Rating TEXT, Feedback TEXT, Type TEXT, VideoUrl TEXT)")
     else:
         # try to upgrade
         column_names = [ x[1] for x in columns]
         if not 'Email' in column_names:
             print('Adding column Email')
             cur.execute("ALTER TABLE Logs ADD COLUMN Email TEXT DEFAULT ''")
-        if not 'Weather' in column_names:
-            print('Adding column Weather')
-            cur.execute("ALTER TABLE Logs ADD COLUMN Weather TEXT DEFAULT ''")
+        if not 'WindSpeed' in column_names:
+            print('Adding column WindSpeed')
+            cur.execute("ALTER TABLE Logs ADD COLUMN WindSpeed INT DEFAULT -1")
         if not 'Rating' in column_names:
             print('Adding column Rating')
             cur.execute("ALTER TABLE Logs ADD COLUMN Rating TEXT DEFAULT ''")
@@ -43,6 +43,9 @@ with con:
         if not 'Type' in column_names:
             print('Adding column Type')
             cur.execute("ALTER TABLE Logs ADD COLUMN Type TEXT DEFAULT ''")
+        if not 'VideoUrl' in column_names:
+            print('Adding column VideoUrl')
+            cur.execute("ALTER TABLE Logs ADD COLUMN VideoUrl TEXT DEFAULT ''")
 
 con.close()
 

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+# Script to create or upgrade the SQLite DB
+
 import sqlite3 as lite
 import sys
 import os
@@ -15,8 +17,32 @@ print('creating DB at '+get_db_filename())
 con = lite.connect(get_db_filename())
 with con:
     cur = con.cursor()
-    cur.execute("CREATE TABLE Logs(Id TEXT, Title TEXT, Description TEXT, "
-            "OriginalFilename TEXT, Date TIMESTAMP, AllowForAnalysis INTEGER, "
-            "Obfuscated INTEGER, Source TEXT)")
+    cur.execute("PRAGMA table_info('Logs')")
+    columns = cur.fetchall()
+
+    if len(columns) == 0:
+        cur.execute("CREATE TABLE Logs(Id TEXT, Title TEXT, Description TEXT, "
+                "OriginalFilename TEXT, Date TIMESTAMP, AllowForAnalysis INTEGER, "
+                "Obfuscated INTEGER, Source TEXT, Email TEXT, Weather TEXT, "
+                "Rating TEXT, Feedback TEXT, Type TEXT)")
+    else:
+        # try to upgrade
+        column_names = [ x[1] for x in columns]
+        if not 'Email' in column_names:
+            print('Adding column Email')
+            cur.execute("ALTER TABLE Logs ADD COLUMN Email TEXT DEFAULT ''")
+        if not 'Weather' in column_names:
+            print('Adding column Weather')
+            cur.execute("ALTER TABLE Logs ADD COLUMN Weather TEXT DEFAULT ''")
+        if not 'Rating' in column_names:
+            print('Adding column Rating')
+            cur.execute("ALTER TABLE Logs ADD COLUMN Rating TEXT DEFAULT ''")
+        if not 'Feedback' in column_names:
+            print('Adding column Feedback')
+            cur.execute("ALTER TABLE Logs ADD COLUMN Feedback TEXT DEFAULT ''")
+        if not 'Type' in column_names:
+            print('Adding column Type')
+            cur.execute("ALTER TABLE Logs ADD COLUMN Type TEXT DEFAULT ''")
+
 con.close()
 

--- a/tornado_handlers.py
+++ b/tornado_handlers.py
@@ -61,7 +61,7 @@ class UploadHandler(tornado.web.RequestHandler):
                 self.ps.data_complete()
                 form_data = self.ps.get_values(['description', 'email',
                     'allowForAnalysis', 'obfuscated', 'source', 'type',
-                    'feedback', 'weather', 'rating'])
+                    'feedback', 'windSpeed', 'rating', 'videoUrl'])
                 description = cgi.escape(form_data['description'].decode("utf-8"))
                 email = form_data['email'].decode("utf-8")
                 upload_type = 'personal'
@@ -82,16 +82,20 @@ class UploadHandler(tornado.web.RequestHandler):
                 feedback = ''
                 if 'feedback' in form_data:
                     feedback = cgi.escape(form_data['feedback'].decode("utf-8"))
-                weather = ''
+                wind_speed = -1
                 rating = ''
                 stored_email = ''
+                video_url = ''
 
                 if upload_type == 'flightreport':
-                    weather = cgi.escape(form_data['weather'].decode("utf-8"))
-                    if weather == 'notset': weather = ''
+                    try:
+                        wind_speed = int(cgi.escape(form_data['windSpeed'].decode("utf-8")))
+                    except ValueError:
+                        wind_speed = -1
                     rating = cgi.escape(form_data['rating'].decode("utf-8"))
                     if rating == 'notset': rating = ''
                     stored_email = email
+                    video_url = cgi.escape(form_data['videoUrl'].decode("utf-8"))
 
                 file_obj = self.ps.get_parts_by_name('filearg')[0]
                 upload_file_name = file_obj.get_filename()
@@ -125,12 +129,13 @@ class UploadHandler(tornado.web.RequestHandler):
                 cur = con.cursor()
                 cur.execute('insert into Logs (Id, Title, Description, '
                         'OriginalFilename, Date, AllowForAnalysis, Obfuscated, '
-                        'Source, Email, Weather, Rating, Feedback, Type) values '
-                        '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        'Source, Email, WindSpeed, Rating, Feedback, Type, '
+                        'videoUrl) values '
+                        '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                         [log_id, title, description, upload_file_name,
                             datetime.datetime.now(), allow_for_analysis,
-                            obfuscated, source, stored_email, weather, rating,
-                            feedback, upload_type])
+                            obfuscated, source, stored_email, wind_speed, rating,
+                            feedback, upload_type, video_url])
                 con.commit()
                 cur.close()
                 con.close()

--- a/upload.html
+++ b/upload.html
@@ -36,31 +36,32 @@ example log. -->
 				</tr>
 				<tr>
 					<td class="left">E-Mail (optional):</td><td><input class="align-right" type="text" name="email" /></td>
-					<tr>
-						<td colspan="2"><small>Will only be used to send you a link to
-								the uploaded file and is not stored on the server.</small></td>
-					</tr>
-					<tr>
-						<td colspan="2">
-							<label><input type="checkbox" name="allowForAnalysis" value="true"> Allow
-								this log file to be used for statistical analysis.</label>
-						</td>
-					</tr>
-					<!--
-					<tr>
+				</tr>
+				<tr>
+					<td colspan="2"><small>Will only be used to send you a link to
+							the uploaded file and is not stored on the server.</small></td>
+				</tr>
+				<tr>
 					<td colspan="2">
-					<label><input type="checkbox" name="obfuscated" value="true">
-					Obfuscate location information in the log.</label>
+						<label><input type="checkbox" name="allowForAnalysis" value="true"> Allow
+							this log file to be used for statistical analysis.</label>
 					</td>
-					</tr>
-					-->
-					<tr>
-						<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
-					</tr>
-					<tr>
-						<td></td><td><input class="btn btn-common align-right"
-						  id="upload-button" type="submit" value="Upload" /></td>
-					</tr>
+				</tr>
+				<!--
+				<tr>
+				<td colspan="2">
+				<label><input type="checkbox" name="obfuscated" value="true">
+				Obfuscate location information in the log.</label>
+				</td>
+				</tr>
+				-->
+				<tr>
+					<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
+				</tr>
+				<tr>
+					<td></td><td><input class="btn btn-common align-right"
+						 id="upload-button" type="submit" value="Upload" /></td>
+				</tr>
 			</form>
 		</table>
 
@@ -76,7 +77,7 @@ example log. -->
 					</td>
 				</tr>
 				<tr>
-					<td class="left">Description:</td><td><input class="align-right" type="text" name="description" /></td>
+					<td class="left">Test Description:</td><td><input class="align-right" type="text" name="description" /></td>
 				</tr>
 				<tr>
 					<td class="left">Additional Feedback:</td><td><textarea
@@ -84,40 +85,45 @@ example log. -->
 				</tr>
 				<tr>
 					<td class="left">E-Mail:</td><td><input class="align-right" type="text" name="email" /></td>
-					<tr>
-						<td colspan="2"><small>May be used to request additional information.</small></td>
-					</tr>
-					<tr>
-						<td class="left">Weather:</td><td>
-							<select class="align-right" name="weather">
-								<option value="notset" selected="selected">Please select:</option>
-								<option value="sunny">Sunny</option>
-								<option value="cloudy">Cloudy</option>
-								<option value="windy">Windy</option>
-								<option value="rainy">Rainy</option>
-								<option value="stormy">Stormy</option>
-							</select>
-						</td>
-					</tr>
-					<tr>
-						<td class="left">Flight Rating:</td>
-						<td>
-							<select class="align-right" name="rating">
-								<option value="notset" selected="selected">Please select:</option>
-								<option value="crash">Crashed</option>
-								<option value="unsatisfactory">Unsatisfactory</option>
-								<option value="good">Good</option>
-								<option value="great">Great!</option>
-							</select>
-						</td>
-					</tr>
-					<tr>
-						<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
-					</tr>
-					<tr>
-						<td></td><td><input class="btn btn-common align-right"
-						  id="upload-button" type="submit" value="Upload" /></td>
-					</tr>
+				</tr>
+				<tr>
+					<td colspan="2"><small>May be used to request additional information.</small></td>
+				</tr>
+				<tr>
+					<td class="left">Wind Speed:</td><td>
+						<select class="align-right" name="windSpeed">
+							<option value="-1" selected="selected">Please select:</option>
+							<!-- Beafort Scale -->
+							<option value="0">Calm</option>
+							<option value="5">Breeze</option>
+							<option value="8">Gale</option>
+							<option value="10">Storm</option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<td class="left">Flight Rating:</td>
+					<td>
+						<select class="align-right" name="rating">
+							<option value="notset" selected="selected">Please select:</option>
+							<option value="crash_pilot">Crashed (Pilot mistake)</option>
+							<option value="crash_sw_hw">Crashed (Software or Hardware issue)</option>
+							<option value="unsatisfactory">Unsatisfactory</option>
+							<option value="good">Good</option>
+							<option value="great">Great!</option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<td class="left">Video Url:</td><td><input class="align-right" type="text" name="videoUrl" /></td>
+				</tr>
+				<tr>
+					<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
+				</tr>
+				<tr>
+					<td></td><td><input class="btn btn-common align-right"
+						 id="upload-button" type="submit" value="Upload" /></td>
+				</tr>
 			</form>
 		</table>
 

--- a/upload.html
+++ b/upload.html
@@ -4,45 +4,126 @@
 <h1>Upload a Log File</h1>
 
 <p>
-Select and upload a log file for plotting and analysis. See TODO for an
-example log.
+Select and upload a log file for plotting and analysis. <!-- See TODO for an
+example log. -->
 </p>
 
 <p>
-<table class="spaced">
-<form enctype="multipart/form-data" action="/upload" method="post">
-	<tr>
-		<td class="left">Description (optional):</td><td><input class="align-right" type="text" name="description" /></td>
-	</tr>
-	<tr>
-		<td class="left">E-Mail (optional):</td><td><input class="align-right" type="text" name="email" /></td>
-	<tr>
-		<td colspan="2"><small>Will only be used to send you a link to
-				the uploaded file and is not stored on the server.</small></td>
-	</tr>
-	<tr>
-		<td colspan="2">
-			<label><input type="checkbox" name="allowForAnalysis" value="true"> Allow
-				this log file to be used for statistical analysis.</label>
-		</td>
-	</tr>
-	<!--
-	<tr>
-		<td colspan="2">
-			<label><input type="checkbox" name="obfuscated" value="true">
-				Obfuscate location information in the log.</label>
-		</td>
-	</tr>
-	-->
-	<tr>
-		<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
-	</tr>
-	<tr>
-		<td></td><td><input class="btn btn-common align-right"
-			id="upload-button" type="submit" value="Upload" /></td>
-	</tr>
-</form>
-</table>
+
+
+<ul class="nav nav-tabs">
+	<li class="active"><a data-toggle="tab" href="#personal">Personal</a></li>
+	<li><a data-toggle="tab" href="#flightreport">Flight Report</a></li>
+</ul>
+
+<div class="tab-content">
+	<div id="personal" class="tab-pane fade in active">
+
+		<!-- Personal Tab -->
+		<table class="spaced">
+			<form enctype="multipart/form-data" action="/upload" method="post">
+				<tr>
+					<td></td><td>
+						<input type="hidden" name="type" value="personal">
+					</td>
+				</tr>
+				<tr>
+					<td class="left">Description (optional):</td><td><input class="align-right" type="text" name="description" /></td>
+				</tr>
+				<tr>
+					<td class="left">Additional Feedback (optional):</td><td><textarea
+		 class="align-right" cols="20" rows="3" name="feedback"></textarea></td>
+				</tr>
+				<tr>
+					<td class="left">E-Mail (optional):</td><td><input class="align-right" type="text" name="email" /></td>
+					<tr>
+						<td colspan="2"><small>Will only be used to send you a link to
+								the uploaded file and is not stored on the server.</small></td>
+					</tr>
+					<tr>
+						<td colspan="2">
+							<label><input type="checkbox" name="allowForAnalysis" value="true"> Allow
+								this log file to be used for statistical analysis.</label>
+						</td>
+					</tr>
+					<!--
+					<tr>
+					<td colspan="2">
+					<label><input type="checkbox" name="obfuscated" value="true">
+					Obfuscate location information in the log.</label>
+					</td>
+					</tr>
+					-->
+					<tr>
+						<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
+					</tr>
+					<tr>
+						<td></td><td><input class="btn btn-common align-right"
+						  id="upload-button" type="submit" value="Upload" /></td>
+					</tr>
+			</form>
+		</table>
+
+	</div>
+	<div id="flightreport" class="tab-pane fade">
+
+		<!-- Flight Report Tab -->
+		<table class="spaced">
+			<form enctype="multipart/form-data" action="/upload" method="post">
+				<tr>
+					<td></td><td>
+						<input type="hidden" name="type" value="flightreport">
+					</td>
+				</tr>
+				<tr>
+					<td class="left">Description:</td><td><input class="align-right" type="text" name="description" /></td>
+				</tr>
+				<tr>
+					<td class="left">Additional Feedback:</td><td><textarea
+					class="align-right" cols="20" rows="3" name="feedback"></textarea></td>
+				</tr>
+				<tr>
+					<td class="left">E-Mail:</td><td><input class="align-right" type="text" name="email" /></td>
+					<tr>
+						<td colspan="2"><small>May be used to request additional information.</small></td>
+					</tr>
+					<tr>
+						<td class="left">Weather:</td><td>
+							<select class="align-right" name="weather">
+								<option value="notset" selected="selected">Please select:</option>
+								<option value="sunny">Sunny</option>
+								<option value="cloudy">Cloudy</option>
+								<option value="windy">Windy</option>
+								<option value="rainy">Rainy</option>
+								<option value="stormy">Stormy</option>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<td class="left">Flight Rating:</td>
+						<td>
+							<select class="align-right" name="rating">
+								<option value="notset" selected="selected">Please select:</option>
+								<option value="crash">Crashed</option>
+								<option value="unsatisfactory">Unsatisfactory</option>
+								<option value="good">Good</option>
+								<option value="great">Great!</option>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<td class="left">ULog File:</td><td><input class="align-right" type="file" name="filearg" /></td>
+					</tr>
+					<tr>
+						<td></td><td><input class="btn btn-common align-right"
+						  id="upload-button" type="submit" value="Upload" /></td>
+					</tr>
+			</form>
+		</table>
+
+	</div>
+</div>
+
 </p>
 
 <p>


### PR DESCRIPTION
This adds a separate tab on the upload page, for flight testing with additional fields like weather & flight rating. It looks like this:
![flight_review_upload](https://cloud.githubusercontent.com/assets/281593/20927729/2ae6d75a-bbc3-11e6-8c9b-4fd02c76b1a0.png)

@dogmaphobic: can you please extend QGC to add these fields?
@sanderux @LorenzMeier @kd0aij Any suggestions for additional fields/changes?