### PR TITLE
Add plotting for vision data

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -236,7 +236,6 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
 
 
 
-
     # Local position
     for axis in ['x', 'y', 'z']:
         data_plot = DataPlot(data, plot_config, 'vehicle_local_position',
@@ -255,7 +254,54 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
     data_plot = DataPlot(data, plot_config, 'vehicle_local_position',
                          y_axis_label='[m/s]', title='Velocity',
                          plot_height='small', changed_params=changed_params)
-    data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['x', 'y', 'z'])
+    data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'])
+    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
+
+    if data_plot.finalize() is not None: plots.append(data_plot)
+
+
+
+    # Vision position
+    data_plot = DataPlot(data, plot_config, 'vehicle_vision_position',
+                         y_axis_label='[m]', title='Vision Position',
+                         plot_height='small', changed_params=changed_params)
+    data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
+    data_plot.change_dataset('vehicle_local_position_groundtruth')
+    data_plot.add_graph(['x', 'y', 'z'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
+    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
+
+    if data_plot.finalize() is not None: plots.append(data_plot)
+
+
+
+    # Vision velocity
+    data_plot = DataPlot(data, plot_config, 'vehicle_vision_position',
+                         y_axis_label='[m]', title='Vision Velocity',
+                         plot_height='small', changed_params=changed_params)
+    data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'])
+    data_plot.change_dataset('vehicle_local_position_groundtruth')
+    data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
+    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
+
+    if data_plot.finalize() is not None: plots.append(data_plot)
+
+
+
+    # Vision attitude
+    data_plot = DataPlot(data, plot_config, 'vehicle_vision_attitude',
+                         y_axis_label='[deg]', title='Vision Attitude',
+                         plot_height='small', changed_params=changed_params)
+    data_plot.add_graph([
+        lambda data: ('roll', np.rad2deg(data['roll'])),
+        lambda data: ('pitch', np.rad2deg(data['pitch'])),
+        lambda data: ('yaw', np.rad2deg(data['yaw']))],
+        colors3, ['Roll', 'Pitch', 'Yaw'])
+    data_plot.change_dataset('vehicle_attitude_groundtruth')
+    data_plot.add_graph([
+        lambda data: ('roll', np.rad2deg(data['roll'])),
+        lambda data: ('pitch', np.rad2deg(data['pitch'])),
+        lambda data: ('yaw', np.rad2deg(data['yaw']))], 
+        colors8[2:5], ['Roll Groundtruth', 'Pitch Groundtruth', 'Yaw Groundtruth'])
     plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
 
     if data_plot.finalize() is not None: plots.append(data_plot)
@@ -317,7 +363,7 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
                          y_axis_label='[m/s^2]', title='Raw Acceleration',
                          plot_height='small', changed_params=changed_params)
     data_plot.add_graph(['accelerometer_m_s2[0]', 'accelerometer_m_s2[1]',
-                         'accelerometer_m_s2[2]'], colors3, ['x', 'y', 'z'])
+                         'accelerometer_m_s2[2]'], colors3, ['X', 'Y', 'Z'])
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 
@@ -330,7 +376,7 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
         lambda data: ('gyro_rad[0]', np.rad2deg(data['gyro_rad[0]'])),
         lambda data: ('gyro_rad[1]', np.rad2deg(data['gyro_rad[1]'])),
         lambda data: ('gyro_rad[2]', np.rad2deg(data['gyro_rad[2]']))],
-                        colors3, ['x', 'y', 'z'])
+                        colors3, ['X', 'Y', 'Z'])
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 
@@ -341,7 +387,7 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
                          plot_height='small', changed_params=changed_params)
     data_plot.add_graph(['magnetometer_ga[0]', 'magnetometer_ga[1]',
                          'magnetometer_ga[2]'], colors3,
-                        ['x', 'y', 'z'])
+                        ['X', 'Y', 'Z'])
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -266,11 +266,13 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
                          y_axis_label='[m]', title='Vision Position',
                          plot_height='small', changed_params=changed_params)
     data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
-    data_plot.change_dataset('vehicle_local_position_groundtruth')
-    data_plot.add_graph(['x', 'y', 'z'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
     plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
 
-    if data_plot.finalize() is not None: plots.append(data_plot)
+    if data_plot.finalize() is not None: 
+        data_plot.change_dataset('vehicle_local_position_groundtruth')
+        data_plot.add_graph(['x', 'y', 'z'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
+
+        plots.append(data_plot)
 
 
 
@@ -279,11 +281,13 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
                          y_axis_label='[m]', title='Vision Velocity',
                          plot_height='small', changed_params=changed_params)
     data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'])
-    data_plot.change_dataset('vehicle_local_position_groundtruth')
-    data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
+    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)    
 
-    if data_plot.finalize() is not None: plots.append(data_plot)
+    if data_plot.finalize() is not None: 
+        data_plot.change_dataset('vehicle_local_position_groundtruth')
+        data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
+
+        plots.append(data_plot)
 
 
 
@@ -296,15 +300,17 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
         lambda data: ('pitch', np.rad2deg(data['pitch'])),
         lambda data: ('yaw', np.rad2deg(data['yaw']))],
         colors3, ['Roll', 'Pitch', 'Yaw'])
-    data_plot.change_dataset('vehicle_attitude_groundtruth')
-    data_plot.add_graph([
-        lambda data: ('roll', np.rad2deg(data['roll'])),
-        lambda data: ('pitch', np.rad2deg(data['pitch'])),
-        lambda data: ('yaw', np.rad2deg(data['yaw']))], 
-        colors8[2:5], ['Roll Groundtruth', 'Pitch Groundtruth', 'Yaw Groundtruth'])
     plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
 
-    if data_plot.finalize() is not None: plots.append(data_plot)
+    if data_plot.finalize() is not None: 
+        data_plot.change_dataset('vehicle_attitude_groundtruth')
+        data_plot.add_graph([
+            lambda data: ('roll', np.rad2deg(data['roll'])),
+            lambda data: ('pitch', np.rad2deg(data['pitch'])),
+            lambda data: ('yaw', np.rad2deg(data['yaw']))], 
+            colors8[2:5], ['Roll Groundtruth', 'Pitch Groundtruth', 'Yaw Groundtruth'])
+
+        plots.append(data_plot)
 
 
 

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -268,9 +268,10 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
     data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
     plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
 
-    if data_plot.finalize() is not None: 
+    if data_plot.finalize() is not None:
         data_plot.change_dataset('vehicle_local_position_groundtruth')
-        data_plot.add_graph(['x', 'y', 'z'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
+        data_plot.add_graph(['x', 'y', 'z'], colors8[2:5],
+                            ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
 
         plots.append(data_plot)
 
@@ -281,11 +282,12 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
                          y_axis_label='[m]', title='Vision Velocity',
                          plot_height='small', changed_params=changed_params)
     data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'])
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)    
+    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
 
-    if data_plot.finalize() is not None: 
+    if data_plot.finalize() is not None:
         data_plot.change_dataset('vehicle_local_position_groundtruth')
-        data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5], ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
+        data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5],
+        	                   ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
 
         plots.append(data_plot)
 
@@ -299,16 +301,17 @@ def generate_plots(ulog, px4_ulog, flight_mode_changes, db_data):
         lambda data: ('roll', np.rad2deg(data['roll'])),
         lambda data: ('pitch', np.rad2deg(data['pitch'])),
         lambda data: ('yaw', np.rad2deg(data['yaw']))],
-        colors3, ['Roll', 'Pitch', 'Yaw'])
+                        colors3, ['Roll', 'Pitch', 'Yaw'])
     plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes)
 
-    if data_plot.finalize() is not None: 
+    if data_plot.finalize() is not None:
         data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([
             lambda data: ('roll', np.rad2deg(data['roll'])),
             lambda data: ('pitch', np.rad2deg(data['pitch'])),
-            lambda data: ('yaw', np.rad2deg(data['yaw']))], 
-            colors8[2:5], ['Roll Groundtruth', 'Pitch Groundtruth', 'Yaw Groundtruth'])
+            lambda data: ('yaw', np.rad2deg(data['yaw']))],
+                            colors8[2:5],
+                            ['Roll Groundtruth', 'Pitch Groundtruth', 'Yaw Groundtruth'])
 
         plots.append(data_plot)
 

--- a/plot_app/helper.py
+++ b/plot_app/helper.py
@@ -220,7 +220,8 @@ def load_ulog_file(file_name):
                   'vehicle_attitude', 'vehicle_attitude_setpoint',
                   'vehicle_rates_setpoint', 'rc_channels', 'input_rc',
                   'position_setpoint_triplet', 'vehicle_attitude_groundtruth',
-                  'vehicle_local_position_groundtruth']
+                  'vehicle_local_position_groundtruth', 'vehicle_vision_position',
+                  'vehicle_vision_attitude']
     ulog = ULog(file_name, msg_filter)
 
     # filter messages with timestamp = 0 (these are invalid).

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -8,7 +8,7 @@ pylint_exec=$(which pylint 2>/dev/null)
 set -e
 
 export PYTHONPATH=plot_app
-python $pylint_exec send_email.py tornado_handlers.py serve.py \
+python3 $pylint_exec send_email.py tornado_handlers.py serve.py \
 	multipart_streamer.py plot_app/*.py
 
 exit 0


### PR DESCRIPTION
@LorenzMeier This adds the plotting for the new vision topics + groundtruth. This needs https://github.com/PX4/pyulog/pull/18 to work.

![bokeh_plot](https://cloud.githubusercontent.com/assets/5557676/23247556/dcf45428-f9c0-11e6-9826-7c539b093310.png)

![bokeh_plot 1](https://cloud.githubusercontent.com/assets/5557676/23247562/e8a0bb0e-f9c0-11e6-9eb3-3692184fe8d7.png)

![bokeh_plot 2](https://cloud.githubusercontent.com/assets/5557676/23247563/e962ce60-f9c0-11e6-890a-4c93af7e29e8.png)

Please review and merge @bkueng.

P.S - Ignore crappy vision performance :P 