### PR TITLE
Show non-default params in a table

### DIFF
--- a/config_default.ini
+++ b/config_default.ini
@@ -6,6 +6,7 @@ domain_name = review.px4.io
 storage_path = data
 
 airframes_url = http://px4-travis.s3.amazonaws.com/Firmware/master/airframes.xml
+parameters_url = http://px4-travis.s3.amazonaws.com/Firmware/master/parameters.xml
 
 # https://developers.google.com/maps/documentation/javascript/get-api-key
 google_maps_api_key =

--- a/plot_app/config.py
+++ b/plot_app/config.py
@@ -23,6 +23,7 @@ email_notifications_config['public_flightreport'] = \
 
 __DOMAIN_NAME = _conf.get('general', 'domain_name')
 __AIRFRAMES_URL = _conf.get('general', 'airframes_url')
+__PARAMETERS_URL = _conf.get('general', 'parameters_url')
 __GMAPS_API_KEY = _conf.get('general', 'google_maps_api_key')
 __LOG_CACHE_SIZE = int(_conf.get('general', 'log_cache_size'))
 
@@ -34,6 +35,7 @@ __LOG_FILE_PATH = os.path.join(__STORAGE_PATH, 'log_files')
 __DB_FILENAME = os.path.join(__STORAGE_PATH, 'logs.sqlite')
 __CACHE_FILE_PATH = os.path.join(__STORAGE_PATH, 'cache')
 __AIRFRAMES_FILENAME = os.path.join(__CACHE_FILE_PATH, 'airframes.xml')
+__PARAMETERS_FILENAME = os.path.join(__CACHE_FILE_PATH, 'parameters.xml')
 
 __PRINT_TIMING = int(_conf.get('debug', 'print_timing'))
 
@@ -87,6 +89,14 @@ def get_airframes_filename():
 def get_airframes_url():
     """ get airframes download URL """
     return __AIRFRAMES_URL
+
+def get_parameters_filename():
+    """ get configured parameters file name """
+    return __PARAMETERS_FILENAME
+
+def get_parameters_url():
+    """ get parameters download URL """
+    return __PARAMETERS_URL
 
 def get_google_maps_api_key():
     """ get Google maps API key """

--- a/plot_app/templates/header.html
+++ b/plot_app/templates/header.html
@@ -43,6 +43,7 @@
                             <ul role="menu" class="sub-menu">
                                 <li><a href="download?log={{ log_id }}">Log File</a></li>
                                 <li><a href="download?log={{ log_id }}&type=1" target="_blank">Parameters</a></li>
+                                <li><a href="download?log={{ log_id }}&type=3" target="_blank">Parameters (non-default)</a></li>
 {% if has_position_data %}
                                 <li><a href="download?log={{ log_id }}&type=2" target="_blank">KML Track</a></li>
 {% endif %}


### PR DESCRIPTION
This adds a table showing the non-default parameters. The default parameters are obtained from the S3 parameters.xml based on master.

Additionally it adds a download option for the non-default params.

![flight_review_non_default_params](https://cloud.githubusercontent.com/assets/281593/23396289/757356f6-fd93-11e6-8517-4bdbbf111b27.png)

@MaEtUgR 