### PR TITLE
Add Statistics Page

### DIFF
--- a/config_default.ini
+++ b/config_default.ini
@@ -17,6 +17,7 @@ log_cache_size = 8
 
 [debug]
 print_timing = 0
+verbose_output = 0
 
 [email]
 # Will use SSL, port 465

--- a/plot_app/config.py
+++ b/plot_app/config.py
@@ -49,7 +49,7 @@ plot_config = dict(
     plot_height = dict(
         normal = int(plot_width / 2.1),
         small = int(plot_width / 2.5),
-        gps_map = int(plot_width / 1.61803398874989484),
+        large = int(plot_width / 1.61803398874989484), # used for the gps map
         ),
     )
 

--- a/plot_app/config.py
+++ b/plot_app/config.py
@@ -37,6 +37,7 @@ __AIRFRAMES_FILENAME = os.path.join(__CACHE_FILE_PATH, 'airframes.xml')
 __PARAMETERS_FILENAME = os.path.join(__CACHE_FILE_PATH, 'parameters.xml')
 
 __PRINT_TIMING = int(_conf.get('debug', 'print_timing'))
+__VERBOSE_OUTPUT = int(_conf.get('debug', 'verbose_output'))
 
 # general configuration variables for plotting
 plot_width = 840
@@ -109,3 +110,7 @@ def get_log_cache_size():
 def debug_print_timing():
     """ print timing information? """
     return __PRINT_TIMING == 1
+
+def debug_verbose_output():
+    """ print verbose output? """
+    return __VERBOSE_OUTPUT == 1

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -204,7 +204,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
 #        gps_titles.append('GPS Map: Plain')
 #
 #    data_plot = DataPlot2D(data, plot_config, 'vehicle_local_position',
-#        x_axis_label = '[m]', y_axis_label='[m]', plot_height='gps_map')
+#        x_axis_label = '[m]', y_axis_label='[m]', plot_height='large')
 #    data_plot.add_graph('y', 'x', colors2[0], 'Estimated')
 #    data_plot.change_dataset('vehicle_local_position_setpoint')
 #    data_plot.add_graph('y', 'x', colors2[1], 'Setpoint')
@@ -217,7 +217,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
 #        tabs = []
 #        for i in range(len(gps_plots)):
 #            tabs.append(Panel(child=gps_plots[i], title=gps_titles[i]))
-#        gps_plot_height=plot_config['plot_height']['gps_map'] + 30
+#        gps_plot_height=plot_config['plot_height']['large'] + 30
 #        plots.append(Tabs(tabs=tabs, width=plot_width, height=gps_plot_height))
 #    elif len(gps_plots) == 1:
 #        plots.extend(gps_plots)
@@ -225,7 +225,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
 
     # Position plot
     data_plot = DataPlot2D(data, plot_config, 'vehicle_local_position',
-                           x_axis_label='[m]', y_axis_label='[m]', plot_height='gps_map')
+                           x_axis_label='[m]', y_axis_label='[m]', plot_height='large')
     data_plot.add_graph('y', 'x', colors2[0], 'Estimated',
                         check_if_all_zero=True)
     data_plot.change_dataset('vehicle_local_position_setpoint')

--- a/plot_app/main.py
+++ b/plot_app/main.py
@@ -13,126 +13,182 @@ from config import *
 from colors import HTML_color_to_RGB
 from db_entry import *
 from configured_plots import generate_plots
+from statistics_plots import StatisticsPlots
 
 #pylint: disable=invalid-name, redefined-outer-name, deprecated-method
 
-start_time = timer()
 
-ulog_file_name = 'test.ulg'
+GET_arguments = curdoc().session_context.request.arguments
+if GET_arguments is not None and 'stats' in GET_arguments:
 
-ulog_file_name = os.path.join(get_log_filepath(), ulog_file_name)
-error_message = ''
-log_id = ''
+    # show the statistics page
 
-try:
-    GET_arguments = curdoc().session_context.request.arguments
+    plots = []
+    start_time = timer()
 
-    if GET_arguments is not None and 'log' in GET_arguments:
-        log_args = GET_arguments['log']
-        if len(log_args) == 1:
-            log_id = str(log_args[0], 'utf-8')
-            if not validate_log_id(log_id):
-                raise ValueError('Invalid log id: {}'.format(log_id))
-            print('GET[log]={}'.format(log_id))
-            ulog_file_name = get_log_filename(log_id)
+    statistics = StatisticsPlots(plot_config, debug_verbose_output())
 
-    ulog = load_ulog_file(ulog_file_name)
-    px4_ulog = PX4ULog(ulog)
-    px4_ulog.add_roll_pitch_yaw()
-
-except ULogException:
-    error_message = ('A parsing error occured when trying to read the file - '
-                     'the log is most likely corrupt.')
-except:
-    print("Error loading file:", sys.exc_info()[0], sys.exc_info()[1])
-    error_message = 'An error occured when trying to read the file.'
+    print_timing("Data Loading Stats", start_time)
+    start_time = timer()
 
 
-print_timing("Data Loading", start_time)
-start_time = timer()
+    # title
+    div = Div(text="<h1>Statistics</h1>")
+    plots.append(widgetbox(div))
 
+    div = Div(text="<h3>All Logs</h3>")
+    plots.append(widgetbox(div))
 
-if error_message == '':
+    p = statistics.plot_log_upload_statistics([colors8[0], colors8[1], colors8[3],
+                                               colors8[4], colors8[5]])
+    plots.append(p)
 
-    # read the data from DB
-    db_data = DBData()
-    vehicle_data = None
-    try:
-        con = sqlite3.connect(get_db_filename(), detect_types=sqlite3.PARSE_DECLTYPES)
-        cur = con.cursor()
-        cur.execute('select Description, Feedback, Type, WindSpeed, Rating, VideoUrl '
-                    'from Logs where Id = ?', [log_id])
-        db_tuple = cur.fetchone()
-        if db_tuple is not None:
-            db_data.description = db_tuple[0]
-            db_data.feedback = db_tuple[1]
-            db_data.type = db_tuple[2]
-            db_data.wind_speed = db_tuple[3]
-            db_data.rating = db_tuple[4]
-            db_data.video_url = db_tuple[5]
+    div = Div(text="<h3>Flight Report Logs <small>(Public Logs only)</small></h3>")
+    # TODO add a per version table?
+    div_info = Div(text="Total Flight Hours over all versions: %.1f"%
+                   statistics.total_public_flight_duration())
+    plots.append(widgetbox([div, div_info]))
 
-        # vehicle data
-        if 'sys_uuid' in ulog.msg_info_dict:
-            sys_uuid = cgi.escape(ulog.msg_info_dict['sys_uuid'])
+    p = statistics.plot_public_airframe_statistics()
+    plots.append(p)
 
-            cur.execute('select LatestLogId, Name, FlightTime '
-                        'from Vehicle where UUID = ?', [sys_uuid])
-            db_tuple = cur.fetchone()
-            if db_tuple is not None:
-                vehicle_data = DBVehicleData()
-                vehicle_data.log_id = db_tuple[0]
-                if len(db_tuple[1]) > 0:
-                    vehicle_data.name = db_tuple[1]
-                try:
-                    vehicle_data.flight_time = int(db_tuple[2])
-                except:
-                    pass
+    p = statistics.plot_public_boards_statistics()
+    plots.append(p)
 
-        cur.close()
-        con.close()
-    except:
-        print("DB access failed:", sys.exc_info()[0], sys.exc_info()[1])
+    p = statistics.plot_public_flight_mode_statistics()
+    plots.append(p)
 
+    # TODO: add a rating pie chart (something like
+    # http://bokeh.pydata.org/en/latest/docs/gallery/donut_chart.html ?)
 
-    # template variables
-    curdoc().template_variables['google_maps_api_key'] = get_google_maps_api_key()
-    curdoc().template_variables['is_plot_page'] = True
-    curdoc().template_variables['log_id'] = log_id
-    flight_modes = [
-        {'name': 'Manual', 'color': HTML_color_to_RGB(flight_modes_table[0][1])},
-        {'name': 'Altitude Control', 'color': HTML_color_to_RGB(flight_modes_table[1][1])},
-        {'name': 'Position Control', 'color': HTML_color_to_RGB(flight_modes_table[2][1])},
-        {'name': 'Acro', 'color': HTML_color_to_RGB(flight_modes_table[6][1])},
-        {'name': 'Stabilized', 'color': HTML_color_to_RGB(flight_modes_table[8][1])},
-        {'name': 'Offboard', 'color': HTML_color_to_RGB(flight_modes_table[7][1])},
-        {'name': 'Rattitude', 'color': HTML_color_to_RGB(flight_modes_table[9][1])},
-        {'name': 'Auto (Mission, RTL, Follow, ...)',
-         'color': HTML_color_to_RGB(flight_modes_table[3][1])}
-        ]
-    curdoc().template_variables['flight_modes'] = flight_modes
-    vtol_modes = [
-        {'name': 'Transition', 'color': HTML_color_to_RGB(vtol_modes_table[1][1])},
-        {'name': 'Fixed-Wing', 'color': HTML_color_to_RGB(vtol_modes_table[2][1])},
-        {'name': 'Multicopter', 'color': HTML_color_to_RGB(vtol_modes_table[3][1])},
-        ]
-    curdoc().template_variables['vtol_modes'] = vtol_modes
+    print_timing("Plotting Stats", start_time)
 
-    plots = generate_plots(ulog, px4_ulog, db_data, vehicle_data)
+    curdoc().template_variables['is_stats_page'] = True
 
-    title = 'Flight Review - '+px4_ulog.get_mav_type()
+    layout = column(plots, sizing_mode='scale_width')
+    curdoc().add_root(layout)
+    curdoc().title = "Flight Review - Statistics"
 
 
 else:
+    # show the plots of a single log
 
-    title = 'Error'
+    start_time = timer()
 
-    div = Div(text="<h3>"+error_message+"</h3>", width=int(plot_width*0.9))
-    plots = [widgetbox(div, width=int(plot_width*0.9))]
+    ulog_file_name = 'test.ulg'
+
+    ulog_file_name = os.path.join(get_log_filepath(), ulog_file_name)
+    error_message = ''
+    log_id = ''
+
+    try:
+
+        if GET_arguments is not None and 'log' in GET_arguments:
+            log_args = GET_arguments['log']
+            if len(log_args) == 1:
+                log_id = str(log_args[0], 'utf-8')
+                if not validate_log_id(log_id):
+                    raise ValueError('Invalid log id: {}'.format(log_id))
+                print('GET[log]={}'.format(log_id))
+                ulog_file_name = get_log_filename(log_id)
+
+        ulog = load_ulog_file(ulog_file_name)
+        px4_ulog = PX4ULog(ulog)
+        px4_ulog.add_roll_pitch_yaw()
+
+    except ULogException:
+        error_message = ('A parsing error occured when trying to read the file - '
+                         'the log is most likely corrupt.')
+    except:
+        print("Error loading file:", sys.exc_info()[0], sys.exc_info()[1])
+        error_message = 'An error occured when trying to read the file.'
 
 
-# layout
-layout = column(plots, sizing_mode='scale_width')
-curdoc().add_root(layout)
-curdoc().title = title
+    print_timing("Data Loading", start_time)
+    start_time = timer()
 
-print_timing("Plotting", start_time)
+
+    if error_message == '':
+
+        # read the data from DB
+        db_data = DBData()
+        vehicle_data = None
+        try:
+            con = sqlite3.connect(get_db_filename(), detect_types=sqlite3.PARSE_DECLTYPES)
+            cur = con.cursor()
+            cur.execute('select Description, Feedback, Type, WindSpeed, Rating, VideoUrl '
+                        'from Logs where Id = ?', [log_id])
+            db_tuple = cur.fetchone()
+            if db_tuple is not None:
+                db_data.description = db_tuple[0]
+                db_data.feedback = db_tuple[1]
+                db_data.type = db_tuple[2]
+                db_data.wind_speed = db_tuple[3]
+                db_data.rating = db_tuple[4]
+                db_data.video_url = db_tuple[5]
+
+            # vehicle data
+            if 'sys_uuid' in ulog.msg_info_dict:
+                sys_uuid = cgi.escape(ulog.msg_info_dict['sys_uuid'])
+
+                cur.execute('select LatestLogId, Name, FlightTime '
+                            'from Vehicle where UUID = ?', [sys_uuid])
+                db_tuple = cur.fetchone()
+                if db_tuple is not None:
+                    vehicle_data = DBVehicleData()
+                    vehicle_data.log_id = db_tuple[0]
+                    if len(db_tuple[1]) > 0:
+                        vehicle_data.name = db_tuple[1]
+                    try:
+                        vehicle_data.flight_time = int(db_tuple[2])
+                    except:
+                        pass
+
+            cur.close()
+            con.close()
+        except:
+            print("DB access failed:", sys.exc_info()[0], sys.exc_info()[1])
+
+
+        # template variables
+        curdoc().template_variables['google_maps_api_key'] = get_google_maps_api_key()
+        curdoc().template_variables['is_plot_page'] = True
+        curdoc().template_variables['log_id'] = log_id
+        flight_modes = [
+            {'name': 'Manual', 'color': HTML_color_to_RGB(flight_modes_table[0][1])},
+            {'name': 'Altitude Control', 'color': HTML_color_to_RGB(flight_modes_table[1][1])},
+            {'name': 'Position Control', 'color': HTML_color_to_RGB(flight_modes_table[2][1])},
+            {'name': 'Acro', 'color': HTML_color_to_RGB(flight_modes_table[6][1])},
+            {'name': 'Stabilized', 'color': HTML_color_to_RGB(flight_modes_table[8][1])},
+            {'name': 'Offboard', 'color': HTML_color_to_RGB(flight_modes_table[7][1])},
+            {'name': 'Rattitude', 'color': HTML_color_to_RGB(flight_modes_table[9][1])},
+            {'name': 'Auto (Mission, RTL, Follow, ...)',
+             'color': HTML_color_to_RGB(flight_modes_table[3][1])}
+            ]
+        curdoc().template_variables['flight_modes'] = flight_modes
+        vtol_modes = [
+            {'name': 'Transition', 'color': HTML_color_to_RGB(vtol_modes_table[1][1])},
+            {'name': 'Fixed-Wing', 'color': HTML_color_to_RGB(vtol_modes_table[2][1])},
+            {'name': 'Multicopter', 'color': HTML_color_to_RGB(vtol_modes_table[3][1])},
+            ]
+        curdoc().template_variables['vtol_modes'] = vtol_modes
+
+        plots = generate_plots(ulog, px4_ulog, db_data, vehicle_data)
+
+        title = 'Flight Review - '+px4_ulog.get_mav_type()
+
+
+    else:
+
+        title = 'Error'
+
+        div = Div(text="<h3>"+error_message+"</h3>", width=int(plot_width*0.9))
+        plots = [widgetbox(div, width=int(plot_width*0.9))]
+
+
+    # layout
+    layout = column(plots, sizing_mode='scale_width')
+    curdoc().add_root(layout)
+    curdoc().title = title
+
+    print_timing("Plotting", start_time)

--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -304,8 +304,8 @@ def plot_map(ulog, config, map_type='plain', api_key=None, setpoints=False,
         # log does not contain the value we are looking for
         print(type(error), "(vehicle_gps_position):", error)
         return None
+    p.toolbar.logo = None
     return p
-
 
 
 class DataPlot:
@@ -495,6 +495,9 @@ class DataPlot:
         p.ygrid.grid_line_alpha = 0.13
         p.ygrid.minor_grid_line_color = 'navy'
         p.ygrid.minor_grid_line_alpha = 0.05
+
+        p.toolbar.logo = None # hide the bokeh logo (we give credit at the
+                            # bottom of the page)
 
         #p.lod_threshold=None # turn off level-of-detail
 

--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -164,7 +164,7 @@ def plot_map(ulog, config, map_type='plain', api_key=None, setpoints=False,
         altitude = cur_dataset.data['alt'][indices] / 1e3 # meters
 
         plots_width = config['plot_width']
-        plots_height = config['plot_height']['gps_map']
+        plots_height = config['plot_height']['large']
         anchor_lat = 0
         anchor_lon = 0
 

--- a/plot_app/static/css/main.css
+++ b/plot_app/static/css/main.css
@@ -86,11 +86,6 @@ td.left {
 }
 
 
-/* bokeh logo */
-.bk-logo-small {
-/*	filter: saturate(70%); */
-	display: none !important; /* hide it: looks much better. We give credit to bokeh on the page */
-}
 /* bokeh plots */
 .bk-plot-layout {
 	/* spacing between plots */

--- a/plot_app/statistics_plots.py
+++ b/plot_app/statistics_plots.py
@@ -1,0 +1,427 @@
+""" Class for statistics plots page """
+import functools
+import re
+import sqlite3
+
+import numpy as np
+
+from bokeh.plotting import figure
+from bokeh.charts import Area
+from bokeh.palettes import viridis # alternatives: magma, inferno
+import bokeh.core.properties as props
+from bokeh.models import (
+    DatetimeTickFormatter, FixedTicker, FuncTickFormatter,
+    HoverTool, ColumnDataSource
+    )
+
+from plotting import TOOLS, ACTIVE_SCROLL_TOOLS
+from config import get_db_filename
+from helper import get_airframe_data, flight_modes_table
+
+
+#pylint: disable=too-few-public-methods,invalid-name,unused-argument,consider-using-enumerate
+#pylint: disable=unsubscriptable-object
+
+class _VersionData(object):
+    """
+    class that contains various information for a single version
+    """
+    def __init__(self):
+        self.boards = {} # flight durations per board
+        self.airframes = {} # flight durations per airframes
+        self.airframes_num_logs = {} # num logs/flights per airframes
+        self.ratings = {}
+        self.flight_mode_durations = {} # flight durations per flight mode
+
+class _Log(object):
+    """
+    container class containing a DB entry for one log
+    """
+
+    re_version_extract = re.compile(r'v([0-9]+)\.([0-9]+)\.?([0-9]*)')
+
+    def __init__(self, db_tuple):
+        self.log_id = db_tuple[0]
+        self.date = db_tuple[1]
+        self.source = db_tuple[2]
+        self.is_public = db_tuple[3]
+        self.rating = db_tuple[4]
+
+        self.duration = 0
+        self.autostart_id = 0
+        self.hardware = ""
+        self.uuid = ""
+        self.sw_version = ""
+        self.flight_mode_durations = []
+
+    def set_generated(self, db_tuple):
+        """ set from a LogsGenerated DB tuple """
+        self.duration = db_tuple[1]
+        self.autostart_id = db_tuple[4]
+        self.hardware = db_tuple[5]
+        self.uuid = db_tuple[11]
+        # the version has typically the form 'v<i>.<j>.<k> <l>', where <l>
+        # indicates whether it's a development version (most of the time it's 0)
+        self.sw_version = db_tuple[10].split(' ')[0]
+
+        self.flight_mode_durations = \
+            [tuple(map(int, x.split(':'))) for x in db_tuple[12].split(',') if len(x) > 0]
+
+
+    @staticmethod
+    def compare_version(ver_a, ver_b):
+        """
+        compare version strings
+        """
+        # if the version is not set, it should be last
+        if ver_a == '': return 1
+        if ver_b == '': return -1
+        versions = [ver_a, ver_b]
+        version_tuples = []
+
+        for version in versions:
+            m = _Log.re_version_extract.match(version)
+            if m:
+                patch = 0
+                if len(m.groups()) == 3:
+                    patch = m.group(3)
+                version_tuples.append((m.group(1), m.group(2), patch))
+        if len(version_tuples) != 2:
+            return -1
+
+        for i in range(3):
+            if version_tuples[0][i] < version_tuples[1][i]:
+                return -1
+            elif version_tuples[0][i] > version_tuples[1][i]:
+                return 1
+        return 0
+
+
+class StatisticsPlots(object):
+    """
+    Class to generate statistics plots from Database entries
+    """
+
+    def __init__(self, plot_config, verbose_output=False):
+
+        self._config = plot_config
+
+        self._verbose_output = verbose_output
+
+        # lists of dates when a _log was uploaded, one list per type
+        self._public_logs_dates = []
+        self._web_ui_logs_dates = []
+        self._qgc_logs_dates = [] # private uploads via QGC
+        self._ci_logs_dates = []
+        self._all_logs_dates = []
+
+        self._public_logs = []
+
+        # read from the DB
+        con = sqlite3.connect(get_db_filename(), detect_types=sqlite3.PARSE_DECLTYPES)
+        with con:
+            cur = con.cursor()
+
+            cur.execute('select Id, Date, Source, Public, Rating from Logs')
+
+            db_tuples = cur.fetchall()
+            for db_tuple in db_tuples:
+                log = _Log(db_tuple)
+
+                self._all_logs_dates.append(log.date)
+                if log.is_public == 1:
+                    self._public_logs_dates.append(log.date)
+                else:
+                    if log.source == 'CI':
+                        self._ci_logs_dates.append(log.date)
+                    elif log.source == 'QGroundControl':
+                        self._qgc_logs_dates.append(log.date)
+                    else:
+                        self._web_ui_logs_dates.append(log.date)
+
+
+                # LogsGenerated: public only
+                if log.is_public != 1:
+                    continue
+
+                cur.execute('select * from LogsGenerated where Id = ?', [log.log_id])
+                db_tuple = cur.fetchone()
+
+                if db_tuple is None:
+                    print("Error: no generated data")
+                    continue
+
+                log.set_generated(db_tuple)
+
+                # filter bogus entries
+                if log.sw_version == 'v0.0.0':
+                    if self._verbose_output:
+                        print('Warning: %s with version=v0.0.0' % log.log_id)
+                    continue
+
+                if log.sw_version == '':
+                    # FIXME: does that still occur and if so why?
+                    if self._verbose_output:
+                        print('Warning: %s version not set' % log.log_id)
+                    continue
+
+                if log.autostart_id == 0:
+                    print('Warning: %s with autostart_id=0' % log.log_id)
+                    continue
+
+                self._public_logs.append(log)
+
+
+        self._version_data = {} # dict of _VersionData items
+        self._all_airframes = set()
+        self._all_boards = set()
+        self._all_ratings = set()
+        self._all_flight_modes = set()
+        self._total_duration = 0 # in hours, public logs only
+
+        for log in self._public_logs:
+            if not log.sw_version in self._version_data:
+                self._version_data[log.sw_version] = _VersionData()
+
+            self._all_airframes.add(str(log.autostart_id))
+            self._all_boards.add(log.hardware)
+            self._all_ratings.add(log.rating)
+
+            cur_version_data = self._version_data[log.sw_version]
+            boards = cur_version_data.boards
+            airframes = cur_version_data.airframes
+            airframes_num_logs = cur_version_data.airframes_num_logs
+            ratings = cur_version_data.ratings
+            flight_modes = cur_version_data.flight_mode_durations
+
+            if not log.hardware in boards:
+                boards[log.hardware] = 0
+            boards[log.hardware] += log.duration / 3600.
+
+            for flight_mode, duration in log.flight_mode_durations:
+                flight_mode_str = str(flight_mode)
+                self._all_flight_modes.add(flight_mode_str)
+                if not flight_mode_str in flight_modes:
+                    flight_modes[flight_mode_str] = 0.
+                flight_modes[flight_mode_str] += duration / 3600.
+
+            autostart_str = str(log.autostart_id)
+            if not autostart_str in airframes:
+                airframes[autostart_str] = 0
+                airframes_num_logs[autostart_str] = 0
+            airframes[autostart_str] += log.duration / 3600.
+            airframes_num_logs[autostart_str] += 1
+
+            if not log.rating in ratings:
+                ratings[log.rating] = 0
+            ratings[log.rating] += 1
+
+            self._total_duration += log.duration / 3600.
+
+
+    def plot_log_upload_statistics(self, colors):
+        """
+        plot upload statistics for different upload types. Each type is a list of
+        datetime of a single upload
+        :param colors: list of 5 colors
+        :return: bokeh plot
+        """
+        title = 'Number of Log Files on the Server'
+        p = figure(title=title, x_axis_label=None,
+                   y_axis_label=None, tools=TOOLS,
+                   active_scroll=ACTIVE_SCROLL_TOOLS)
+
+        def plot_dates(p, dates_list, legend, color):
+            """ plot a single line from a list of dates """
+            counts = np.arange(1, len(dates_list)+1)
+
+            # subsample
+            dates_list_subsampled = []
+            counts_subsampled = []
+            previous_timestamp = 0
+            for date, count in zip(dates_list, counts):
+                t = int(date.timestamp()/(3600*4)) # use a granularity of 4 hours
+                if t != previous_timestamp:
+                    previous_timestamp = t
+                    dates_list_subsampled.append(date)
+                    counts_subsampled.append(count)
+
+            p.line(dates_list_subsampled, counts_subsampled,
+                   legend=legend, line_width=2, line_color=color)
+
+        plot_dates(p, self._all_logs_dates, 'Total', colors[0])
+        plot_dates(p, self._ci_logs_dates, 'Continuous Integration (Simulation Tests)', colors[1])
+        plot_dates(p, self._web_ui_logs_dates, 'Private (via Web UI)', colors[2])
+        plot_dates(p, self._qgc_logs_dates, 'Private (via QGC)', colors[3])
+        plot_dates(p, self._public_logs_dates, 'Public', colors[4])
+
+        p.xaxis.formatter = DatetimeTickFormatter(
+            hours=["%d %b %Y %H:%M"],
+            days=["%d %b %Y"],
+            months=["%d %b %Y"],
+            years=["%d %b %Y"],
+            )
+        self._setup_plot(p, 'large')
+
+        return p
+
+    def total_public_flight_duration(self):
+        """ get total public flight hours """
+        return self._total_duration
+
+
+    def plot_public_boards_statistics(self):
+        """
+        plot board flight hour statistics for each version, for public logs
+        :return: bokeh plot
+        """
+
+        return self._plot_public_data_statistics(
+            self._all_boards, 'boards', 'Board', lambda x, short: x)
+
+
+    def plot_public_airframe_statistics(self):
+        """
+        plot airframe flight hour statistics for each version, for public logs
+        :return: bokeh plot
+        """
+
+        def label_callback(airframe_id, short):
+            """ get the airframe label for the sys_autostart id """
+            if short:
+                return airframe_id
+            airframe_data = get_airframe_data(airframe_id)
+            if airframe_data is None:
+                airframe_label = airframe_id
+            else:
+                airframe_type = ''
+                if 'type' in airframe_data:
+                    airframe_type = ', '+airframe_data['type']
+                airframe_label = airframe_data.get('name')+ \
+                                   airframe_type+' ('+airframe_id+')'
+            return airframe_label
+
+        return self._plot_public_data_statistics(
+            self._all_airframes, 'airframes', 'Airframe', label_callback)
+
+    def plot_public_flight_mode_statistics(self):
+        """
+        plot flight mode statistics for each version, for public logs
+        :return: bokeh plot
+        """
+
+        def label_callback(flight_mode, short):
+            """ get flight mode as string from an integer value """
+            try:
+                return flight_modes_table[int(flight_mode)][0]
+            except:
+                return 'Unknown'
+
+        return self._plot_public_data_statistics(
+            self._all_flight_modes, 'flight_mode_durations', 'Flight Mode', label_callback)
+
+    def _plot_public_data_statistics(self, all_data, version_attr_name,
+                                     title_name, label_cb):
+        """
+        generic method to plot flight hours one data type
+        :param all_data: list with all types as string
+        :param version_attr_name: attribute name of _VersionData
+        :param title_name: name of the data for the title (and hover tool)
+        :param label_cb: callback to create the label
+        :return: bokeh plot
+        """
+
+        # change data structure
+        data_hours = {} # key=data id, value=list of hours for each version
+        for d in all_data:
+            data_hours[d] = []
+
+        versions = [] # sorted list of all versions
+        for ver in sorted(self._version_data, key=functools.cmp_to_key(_Log.compare_version)):
+            versions.append(ver)
+
+            # all data points of the requested type for this version
+            version_type_data = getattr(self._version_data[ver],
+                                        version_attr_name)
+
+            for d in all_data:
+                if not d in version_type_data:
+                    version_type_data[d] = 0.
+                data_hours[d].append(version_type_data[d])
+
+
+        # cumulative over each version
+        for key in all_data:
+            data_hours[key] = np.array(data_hours[key])
+            data_hours[key+"_cum"] = np.cumsum(data_hours[key])
+
+
+        # create a 2D numpy array. We could directly pass the dict to the bokeh
+        # plot, but then we don't have control over the sorting order
+        X = np.zeros((len(all_data), len(versions)))
+        i = 0
+        all_data_sorted = []
+        for key in sorted(all_data, key=lambda data_key: data_hours[data_key+"_cum"][-1]):
+            X[i, :] = data_hours[key+"_cum"]
+            all_data_sorted.append(key)
+            i += 1
+        all_data = all_data_sorted
+
+
+        colors = viridis(len(all_data))
+        # alternative: use patches: http://bokeh.pydata.org/en/latest/docs/gallery/brewer.html
+        area = Area(X, title="Flight Hours per "+title_name, tools=TOOLS,
+                    active_scroll=ACTIVE_SCROLL_TOOLS,
+                    stack=True, xlabel='version (including development states)',
+                    ylabel='', color=colors)
+
+        # now set the labels
+        for i in range(len(all_data)):
+            area.legend[0].items[i].label = props.value(label_cb(all_data[i], False))
+        area.legend[0].items.reverse()
+
+        # stack the data: we'll need it for the hover tool
+        last = np.zeros(len(versions))
+        for i in range(len(all_data)):
+            last = last + X[i, :]
+            data_hours[all_data[i]+'_stacked'] = last
+        data_hours['x'] = np.arange(len(versions))
+
+        # hover tool
+        source = ColumnDataSource(data=data_hours)
+        for d in all_data:
+            renderer = area.circle(x='x', y=d+'_stacked', source=source,
+                                   size=10, alpha=0, name=d)
+            g1_hover = HoverTool(
+                renderers=[renderer],
+                tooltips=[(title_name, label_cb(d, True)),
+                          ('Flight hours (only this version)', '@'+d+'{0,0.0}'),
+                          ('Flight hours (up to this version)', '@'+d+'_cum{0,0.0}')])
+            area.add_tools(g1_hover)
+
+
+        # TODO: space x-axis entries according to version release date?
+        area.xaxis.formatter = FuncTickFormatter(code="""
+            var versions = """ + str(versions) + """;
+            return versions[Math.floor(tick)]
+        """)
+        area.xaxis.ticker = FixedTicker(ticks=list(range(len(versions))))
+        self._setup_plot(area)
+        return area
+
+
+    def _setup_plot(self, p, plot_height='normal'):
+        """ apply layout options to a bokeh plot """
+
+        plots_width = self._config['plot_width']
+        plots_height = self._config['plot_height'][plot_height]
+        p.plot_width = plots_width
+        p.plot_height = plots_height
+
+        p.xgrid.grid_line_color = 'navy'
+        p.xgrid.grid_line_alpha = 0.13
+        p.ygrid.grid_line_color = 'navy'
+        p.ygrid.grid_line_alpha = 0.13
+        p.legend.location = "top_left"
+        p.toolbar.logo = None
+

--- a/plot_app/templates/footer.html
+++ b/plot_app/templates/footer.html
@@ -5,7 +5,7 @@
                     <div class="copyright-text text-center">
 						<p>&copy; 2016 PX4 Team. Source on <a
 						 href="https://github.com/PX4/flight_review">github</a>.
-{% if is_plot_page %}
+{% if is_plot_page or is_stats_page %}
 						 Plotted with the awesome <a target="_blank"
 						 href="http://bokeh.pydata.org">bokeh</a> library.
 {% endif %}

--- a/plot_app/templates/header.html
+++ b/plot_app/templates/header.html
@@ -36,6 +36,9 @@
                 <div class="col-xs-">
                     <ul class="nav navbar-nav navbar-right">
                         <li _class="active"><a href="upload">Upload</a></li>
+{% if not is_plot_page %}
+                        <li ><a href="stats">Statistics</a></li>
+{% endif %}
                         <li ><a href="browse">Browse</a></li>
 
 {% if is_plot_page %}

--- a/plot_app/templates/index.html
+++ b/plot_app/templates/index.html
@@ -38,8 +38,9 @@ function initMap() {
 {% endif %}
 
 
-
+{% if is_plot_page %}
 <div id="loading-plots" style="height: 50px;"><p><big>Loading Plots...</big></p></div>
+{% endif %}
 
 {{ plot_div|indent(8) }}
 

--- a/plot_app/templates/main.js
+++ b/plot_app/templates/main.js
@@ -108,6 +108,21 @@ function setSize(size) {
 {% endif %} {# is_plot_page #}
 
 
+{% if is_stats_page %}
+// ok, this is ugly: there are too many hover tools (one per airframe in a
+// single plot), so hide them from the toolbar here. Some actions like resetting
+// the plot make them reappear, so we continuously repeat the call.
+function hide_bokeh_hover_tool() {
+	$(".bk-tool-icon-hover").parent('div').css("display", "none");
+	window.setTimeout(hide_bokeh_hover_tool, 200);
+}
+
+$(function() { //on startup
+	window.setTimeout(hide_bokeh_hover_tool, 500);
+});
+
+{% endif %} {# is_stats_page #}
+
 // auto-hide sticky header when scrolling down, show when scrolling up
 // source: http://osvaldas.info/auto-hide-sticky-header
 ;( function( $, window, document, undefined )

--- a/prune_old_logs.py
+++ b/prune_old_logs.py
@@ -14,7 +14,7 @@ from plot_app.config import get_db_filename
 from plot_app.helper import get_log_filename
 
 
-parser = argparse.ArgumentParser(description='Remove a DB entry (but not the log file)')
+parser = argparse.ArgumentParser(description='Remove old log files & DB entries')
 
 parser.add_argument('--max-age', action='store', type=int, default=30,
         help='maximum age in days (delete logs older than this, default=30)')

--- a/pylintrc
+++ b/pylintrc
@@ -99,7 +99,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_,e,h,m,s,m1,s1,h1,p,x,y,t,_p
+good-names=i,j,k,ex,Run,_,e,h,m,s,m1,s1,h1,p,x,y,t,_p,d
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
@@ -269,7 +269,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy
+ignored-modules=numpy,bokeh.palettes
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/serve.py
+++ b/serve.py
@@ -15,6 +15,7 @@ from bokeh.application.handlers import DirectoryHandler
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'plot_app'))
 from helper import set_log_id_is_filename, print_cache_info
 from config import debug_print_timing
+from tornado.web import RedirectHandler
 from tornado_handlers import DownloadHandler, UploadHandler, BrowseHandler, \
     EditEntryHandler
 
@@ -87,7 +88,8 @@ extra_patterns = [
     (r'/browse', BrowseHandler),
     (r'/edit_entry', EditEntryHandler),
     (r'/?', UploadHandler), #root should point to upload
-    (r'/download', DownloadHandler)
+    (r'/download', DownloadHandler),
+    (r"/stats", RedirectHandler, {"url": "/plot_app?stats=1"}),
 ]
 
 server = Server(applications, extra_patterns=extra_patterns, **server_kwargs)

--- a/setup_db.py
+++ b/setup_db.py
@@ -102,6 +102,7 @@ with con:
                 "FlightModes TEXT, " # all flight modes as comma-separated int's
                 "SoftwareVersion TEXT, " # release version
                 "UUID TEXT, " # vehicle UUID (sys_uuid in log)
+                "FlightModeDurations TEXT, " # comma-separated list of <flight_mode_int>:<duration_sec>
                 "CONSTRAINT Id_PK PRIMARY KEY (Id))")
 
     else:
@@ -114,6 +115,9 @@ with con:
         if not 'UUID' in column_names:
             print('Adding column UUID')
             cur.execute("ALTER TABLE LogsGenerated ADD COLUMN UUID TEXT DEFAULT ''")
+        if not 'FlightModeDurations' in column_names:
+            print('Adding column FlightModeDurations')
+            cur.execute("ALTER TABLE LogsGenerated ADD COLUMN FlightModeDurations TEXT DEFAULT ''")
 
 
     # Vehicle table (contains information about a vehicle)


### PR DESCRIPTION
Looks like this:
![flight_review_stats_page](https://cloud.githubusercontent.com/assets/281593/26394224/7f3e814e-406c-11e7-82cb-48a5ab0fa37f.png)

There's also a mouse-over hover tool showing more details:
![flight_review_stats_page_hover](https://cloud.githubusercontent.com/assets/281593/26394391/18522a20-406d-11e7-8041-c82ab7b102e1.png)

I can add some more, like a pie chart for the rating, but in general I'd like to keep a small set of meaningful plots, rather than many that are not that useful.

@dagar the airframes xml from http://px4-travis.s3.amazonaws.com/Firmware/master/airframes.xml does not contain the Intel Aero - probably because it's excluded on some boards. However running `make px4_metadata` in FW does contain it. Am I using the wrong URL?

@LorenzMeier is this about what you had in mind for https://github.com/PX4/flight_review/issues/9 and #7?