### PR TITLE
Stats page updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It uses the [bokeh](http://bokeh.pydata.org) library for plotting and the
 
 - clone the repository
 - use python3
-- `pip3 install bokeh jinja2 pyulog pandas simplekml` (at least version 0.12.5
+- `pip3 install bokeh jinja2 pyulog simplekml` (at least version 0.12.5
   of bokeh is required)
 - `sudo apt-get install sqlite3`
 - configure web server config (this can be skipped for a local installation):

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -600,10 +600,21 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                          y_start=0, title='Estimator Watchdog',
                          plot_height='small', changed_params=changed_params,
                          x_range=x_range)
-    data_plot.add_graph(['nan_flags', 'health_flags',
-                         'timeout_flags'], colors3,
-                        ['NaN Flags', 'Health Flags (vel, pos, hgt)',
-                         'Timeout Flags (vel, pos, hgt)'])
+    data_plot.add_graph(
+        ['nan_flags', 'health_flags', 'timeout_flags',
+         lambda data: ('innovation_check_flags_vel_pos', data['innovation_check_flags']&0x7),
+         lambda data: ('innovation_check_flags_mag', (data['innovation_check_flags']>>3)&0x7),
+         lambda data: ('innovation_check_flags_yaw', (data['innovation_check_flags']>>7)&0x1),
+         lambda data: ('innovation_check_flags_airspeed', (data['innovation_check_flags']>>7)&0x3),
+         lambda data: ('innovation_check_flags_flow', (data['innovation_check_flags']>>9)&0x3)],
+        colors8,
+        ['NaN Flags', 'Health Flags (vel, pos, hgt)',
+         'Timeout Flags (vel, pos, hgt)',
+         'Innovation Check Bits (vel, hor pos, vert pos)',
+         'Innovation Check Bits (mag X, Y, Z)',
+         'Innovation Check Bits (yaw)',
+         'Innovation Check Bits (airspeed, height to ground)',
+         'Innovation Check Bits (optical flow X, Y)'])
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -657,6 +657,9 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
 
         data_plot.add_graph([lambda data: ('timediff', np.append(sampling_diff, 0))],
                             [colors3[2]], ['delta t (between 2 samples)'])
+        data_plot.change_dataset('estimator_status')
+        data_plot.add_graph([lambda data: ('time_slip', data['time_slip']*1e6)],
+                            [colors3[1]], ['Estimator time slip (cumulative)'])
         if data_plot.finalize() is not None: plots.append(data_plot)
     except:
         pass

--- a/plot_app/main.py
+++ b/plot_app/main.py
@@ -42,6 +42,10 @@ if GET_arguments is not None and 'stats' in GET_arguments:
     p = statistics.plot_log_upload_statistics([colors8[0], colors8[1], colors8[3],
                                                colors8[4], colors8[5]])
     plots.append(p)
+    div_info = Div(text="Number of Continous Integration (Simulation Tests) Logs: %i<br />" \
+            "Total Number of Logs on the Server: %i" %
+                   (statistics.num_logs_ci(), statistics.num_logs_total()))
+    plots.append(widgetbox(div_info))
 
     div = Div(text="<h3>Flight Report Logs <small>(Public Logs only)</small></h3>")
     # TODO add a per version table?

--- a/plot_app/main.py
+++ b/plot_app/main.py
@@ -55,6 +55,9 @@ if GET_arguments is not None and 'stats' in GET_arguments:
     p = statistics.plot_public_boards_statistics()
     plots.append(p)
 
+    p = statistics.plot_public_boards_num_flights_statistics()
+    plots.append(p)
+
     p = statistics.plot_public_flight_mode_statistics()
     plots.append(p)
 

--- a/plot_app/statistics_plots.py
+++ b/plot_app/statistics_plots.py
@@ -516,6 +516,12 @@ class StatisticsPlots(object):
             return versions[Math.floor(tick)]
         """)
         area.xaxis.ticker = FixedTicker(ticks=list(data_hours['x']))
+
+        # decrease size a bit to fit all items
+        area.legend.label_text_font_size = '8pt'
+        area.legend.label_height = 8
+        area.legend.glyph_height = 10
+
         self._setup_plot(area)
         return area
 


### PR DESCRIPTION
- Do not show CI logs, only show the total number instead, so that the private logs graph is better visible (the CI graph is not really interesting, as it's just linearly increasing).
![flight_review_stats_page_update](https://user-images.githubusercontent.com/281593/27533179-f5b1f18e-5a62-11e7-920c-467f6a0b9282.png)
- Add plot: number of flights per board

- show innovation check flags in estimator watchdog
- plot ekf2 time slip
![flight_review_estimator_time_slip](https://user-images.githubusercontent.com/281593/27533199-023bb6ce-5a63-11e7-8e8a-61cb6e6c4ce1.png)
@priseborough This reveals there's a time slip of 20ms every time a parameter gets changed. Do you think that's an issue? Also the time continuously slightly increases. Is it due to floating point inaccuracies or is some scheduling overhead not taken into account?

Fixes https://github.com/PX4/flight_review/issues/42 #44