### PR TITLE
Show hardfaults, perf & top data

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -189,7 +189,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
     # hardfault
     if 'hardfault_plain' in ulog.msg_info_multiple_dict:
         hardfault_html = (
-            '<p><b>This log contains hardfault data from a software crash</b> (see <a '
+            '<p><b> <font color="#e0212d">This log contains hardfault data from a software crash'
+            '</font></b> (see <a '
             'href="https://dev.px4.io/en/debug/gdb_debugging.html#debugging-hard-faults-in-nuttx">'
             'here</a> how to debug):</p>')
         counter = 1

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -186,6 +186,18 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
     plots.append(widgetbox(header_divs, width=int(plot_width*0.9)))
 
 
+    # hardfault
+    if 'hardfault_plain' in ulog.msg_info_multiple_dict:
+        hardfault_html = '<p><b>This log contains hardfault data from a software crash</b> ' \
+        '(see <a href="https://dev.px4.io/en/debug/gdb_debugging.html#debugging-hard-faults-in-nuttx">here</a> how to debug):</p>'
+        counter = 1
+        for hardfault in ulog.msg_info_multiple_dict['hardfault_plain']:
+            hardfault_text = cgi.escape(''.join(hardfault)).replace('\n', '<br/>')
+            hardfault_html += '<p>Hardfault #'+str(counter)+':<br/><pre>'+hardfault_text+'</pre></p>'
+            counter += 1
+        hardfault_div = Div(text=hardfault_html, width=int(plot_width*0.9))
+        plots.append(widgetbox(hardfault_div, width=int(plot_width*0.9)))
+
 
 # FIXME: for now, we use Google maps directly without bokeh, because it's not working reliably
     # GPS map

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -188,12 +188,15 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
 
     # hardfault
     if 'hardfault_plain' in ulog.msg_info_multiple_dict:
-        hardfault_html = '<p><b>This log contains hardfault data from a software crash</b> ' \
-        '(see <a href="https://dev.px4.io/en/debug/gdb_debugging.html#debugging-hard-faults-in-nuttx">here</a> how to debug):</p>'
+        hardfault_html = (
+            '<p><b>This log contains hardfault data from a software crash</b> (see <a '
+            'href="https://dev.px4.io/en/debug/gdb_debugging.html#debugging-hard-faults-in-nuttx">'
+            'here</a> how to debug):</p>')
         counter = 1
         for hardfault in ulog.msg_info_multiple_dict['hardfault_plain']:
             hardfault_text = cgi.escape(''.join(hardfault)).replace('\n', '<br/>')
-            hardfault_html += '<p>Hardfault #'+str(counter)+':<br/><pre>'+hardfault_text+'</pre></p>'
+            hardfault_html += ('<p>Hardfault #'+str(counter)+':<br/><pre>'+
+                               hardfault_text+'</pre></p>')
             counter += 1
         hardfault_div = Div(text=hardfault_html, width=int(plot_width*0.9))
         plots.append(widgetbox(hardfault_div, width=int(plot_width*0.9)))

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -810,6 +810,37 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
     plots.append(widgetbox(div, data_table, width=plot_width))
 
 
+    # perf & top output
+    top_data = ''
+    perf_data = ''
+    for state in ['pre', 'post']:
+        if 'perf_top_'+state+'flight' in ulog.msg_info_multiple_dict:
+            current_top_data = ulog.msg_info_multiple_dict['perf_top_'+state+'flight'][0]
+            flight_data = cgi.escape('\n'.join(current_top_data))
+            top_data += '<p>'+state.capitalize()+' Flight:<br/><pre>'+flight_data+'</pre></p>'
+        if 'perf_counter_'+state+'flight' in ulog.msg_info_multiple_dict:
+            current_perf_data = ulog.msg_info_multiple_dict['perf_counter_'+state+'flight'][0]
+            flight_data = cgi.escape('\n'.join(current_perf_data))
+            perf_data += '<p>'+state.capitalize()+' Flight:<br/><pre>'+flight_data+'</pre></p>'
+
+    additional_data_html = ''
+    if len(top_data) > 0:
+        additional_data_html += '<h4>Processes</h4>'+top_data
+    if len(perf_data) > 0:
+        additional_data_html += '<h4>Performance Counters</h4>'+perf_data
+    if len(additional_data_html) > 0:
+        # hide by default & use a button to expand
+        additional_data_html = '''
+<button class="btn btn-common" data-toggle="collapse" style="min-width:0;"
+ data-target="#show-additional-data">Show additional Data</button>
+<div id="show-additional-data" class="collapse">
+{:}
+</div>
+'''.format(additional_data_html)
+        additional_data_div = Div(text=additional_data_html, width=int(plot_width*0.9))
+        plots.append(widgetbox(additional_data_div, width=int(plot_width*0.9)))
+
+
     curdoc().template_variables['plots'] = jinja_plot_data
 
     return plots


### PR DESCRIPTION
Hardfaults are shown at the top so they cannot be overlooked:
![flight_review_hardfault](https://user-images.githubusercontent.com/281593/28118218-7e296236-6710-11e7-8716-0928a8141028.png)

Perf & top data is at the botton using an expand button:
![flight_review_perf_and_top](https://user-images.githubusercontent.com/281593/28118166-5cd6b6ce-6710-11e7-95d5-03e08b98b577.png)
