### PR TITLE
Fix /dbinfo Content-Type

### DIFF
--- a/tornado_handlers.py
+++ b/tornado_handlers.py
@@ -736,6 +736,7 @@ class DBInfoHandler(tornado.web.RequestHandler):
         cur.close()
         con.close()
 
+        self.set_header('Content-Type', 'application/json')
         self.write(json.dumps(jsonlist))
 
 class EditEntryHandler(tornado.web.RequestHandler):


### PR DESCRIPTION
The content type was `text/html`, but should be `application/json`.