### PR TITLE
download_logs: fix script syntax error and default to HTTPS

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -3,4 +3,5 @@ log_files/*-*-*-*-*.ulg
 airframes.xml
 
 /cache/
+/downloaded/
 

--- a/download_logs.py
+++ b/download_logs.py
@@ -16,9 +16,9 @@ def get_arguments():
                         help='Whether to only print (not download) the database entries.')
     parser.add_argument('--overwrite', action='store_true', default=False,
                         help='Whether to overwrite already existing files in download folder.')
-    parser.add_argument('--db-info-api', type=str, default="http://review.px4.io/dbinfo",
+    parser.add_argument('--db-info-api', type=str, default="https://review.px4.io/dbinfo",
                         help='The url at which the server provides the dbinfo API.')
-    parser.add_argument('--download-api', type=str, default="http://review.px4.io/download",
+    parser.add_argument('--download-api', type=str, default="https://review.px4.io/download",
                         help='The url at which the server provides the download API.')
     return parser.parse_args()
 

--- a/download_logs.py
+++ b/download_logs.py
@@ -4,6 +4,7 @@ import os, glob
 import argparse
 import requests
 
+
 def get_arguments():
     parser = argparse.ArgumentParser(description='Python script for downloading public logs from the PX4/flight_review database.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -11,7 +12,7 @@ def get_arguments():
                         help='Maximum number of files to download that match the search criteria. set to -1 to download all files.')
     parser.add_argument('-d', '--download-folder', type=str, default="data/downloaded/",
                         help='The folder to store the downloaded logfiles.')
-    parser.add_argument('--print', action='store_true',
+    parser.add_argument('--print', action='store_true', dest="print_entries",
                         help='Whether to only print (not download) the database entries.')
     parser.add_argument('--overwrite', action='store_true', default=False,
                         help='Whether to overwrite already existing files in download folder.')
@@ -21,19 +22,18 @@ def get_arguments():
                         help='The url at which the server provides the download API.')
     return parser.parse_args()
 
-def main():
 
+def main():
     args = get_arguments()
 
     try:
         # the db_info_api sends a json file with a list of all public database entries
         db_entries_list = requests.get(url=args.db_info_api).json()
-
     except:
         print("Server request failed.")
         raise
 
-    if args.print:
+    if args.print_entries:
         # only print the json output
         print(db_entries_list)
     else:
@@ -69,6 +69,7 @@ def main():
 
         print('{:} logs downloaded to {:}, {:} logs skipped (already downloaded)'.format(
             n_downloaded, args.download_folder, n_skipped))
+
 
 if __name__ == '__main__':
     main()

--- a/download_logs.py
+++ b/download_logs.py
@@ -39,7 +39,7 @@ def main():
     else:
         if not os.path.isdir(args.download_folder):
             print("creating download directory " + args.download_folder)
-            os.mkdir(args.download_folder)
+            os.makedirs(args.download_folder)
         # find already existing logs in download folder
         logfile_pattern = os.path.join(os.path.abspath(args.download_folder), "*.ulg")
         logfiles = glob.glob(os.path.join(os.getcwd(), logfile_pattern))


### PR DESCRIPTION
As is, the `download_logs.py` script fails due to a syntax error:

```bash
$ python download_logs.py
  File "download_logs.py", line 35
    if args.print:
                ^
SyntaxError: invalid syntax
```

This is now fixed without changing the API.

Also changed the default URLs to point to HTTPS instead to avoid relying on the server-side redirect for security. 

Finally, downloaded logs are no longer tracked, and this script won't fail if the intermediary directories in download path specified don't exist yet.