### PR TITLE
statistics page: fix IndexError

### DIFF
--- a/plot_app/statistics_plots.py
+++ b/plot_app/statistics_plots.py
@@ -505,7 +505,8 @@ class StatisticsPlots(object):
             area.patch(x2, stacked_patches[i], color=colors[i],
                        legend=label_cb(all_data[i], False), alpha=0.8, line_color=None)
 
-        area.legend[0].items.reverse()
+        if area.legend:
+            area.legend[0].items.reverse()
 
         area.xaxis.formatter = FuncTickFormatter(code="""
             var versions = """ + str(versions_spaced) + """;


### PR DESCRIPTION
For some reason, without this change I get this error when visiting the `/stats` page:

```bash
File "statistics_plots.py", line 510, in _plot_public_data_statistics:
area.legend[0].items.reverse() Traceback (most recent call last):
   File "/usr/local/lib/python3.5/dist-packages/bokeh/application/handlers/code_runner.py", line 81, in run
     exec(self._code, module.__dict__)
   File "/home/robotics/flight_review/plot_app/main.py", line 65, in <module>
     p = statistics.plot_public_flight_mode_statistics()
   File "/home/robotics/flight_review/plot_app/statistics_plots.py", line 397, in plot_public_flight_mode_statistics
     self._all_flight_modes, 'flight_mode_durations', 'Flight Mode', label_callback)
   File "/home/robotics/flight_review/plot_app/statistics_plots.py", line 510, in _plot_public_data_statistics
     area.legend[0].items.reverse()
 IndexError: list index out of range
```