### PR TITLE
plots: use step lines for attitude, rates & position setpoint graphs

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -183,7 +183,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                             colors2[0:1], [axis_name+' Estimated'], mark_nan=True)
         data_plot.change_dataset('vehicle_attitude_setpoint')
         data_plot.add_graph([lambda data: (axis+'_d', np.rad2deg(data[axis+'_d']))],
-                            colors2[1:2], [axis_name+' Setpoint'], mark_nan=True)
+                            colors2[1:2], [axis_name+' Setpoint'],
+                            mark_nan=True, use_step_lines=True)
         data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
                             [color_gray], [axis_name+' Groundtruth'])
@@ -200,7 +201,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                             colors2[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
         data_plot.change_dataset('vehicle_rates_setpoint')
         data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
-                            colors2[1:2], [axis_name+' Rate Setpoint'], mark_nan=True)
+                            colors2[1:2], [axis_name+' Rate Setpoint'],
+                            mark_nan=True, use_step_lines=True)
         data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: (axis+'speed', np.rad2deg(data[axis+'speed']))],
                             [color_gray], [axis_name+' Rate Groundtruth'])
@@ -218,7 +220,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                              x_range=x_range)
         data_plot.add_graph([axis], colors2[0:1], [axis.upper()+' Estimated'], mark_nan=True)
         data_plot.change_dataset('vehicle_local_position_setpoint')
-        data_plot.add_graph([axis], colors2[1:2], [axis.upper()+' Setpoint'], mark_nan=True)
+        data_plot.add_graph([axis], colors2[1:2], [axis.upper()+' Setpoint'],
+                            mark_nan=True, use_step_lines=True)
         plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)

--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -406,13 +406,16 @@ class DataPlot:
             self._cur_dataset = None
 
 
-    def add_graph(self, field_names, colors, legends, use_downsample=True, mark_nan=False):
+    def add_graph(self, field_names, colors, legends, use_downsample=True,
+                  mark_nan=False, use_step_lines=False):
         """ add 1 or more lines to a graph
 
         field_names can be a list of fields from the data set, or a list of
         functions with the data set as argument and returning a tuple of
         (field_name, data)
         :param mark_nan: if True, add an indicator to the plot when one of the graphs is NaN
+        :param use_step_lines: if True, render step lines (after each point)
+        instead of rendering a straight line to the next point
         """
         if self._had_error: return
         try:
@@ -460,8 +463,13 @@ class DataPlot:
                 data_source = ColumnDataSource(data=data_set)
 
             for field_name, color, legend in zip(field_names_expanded, colors, legends):
-                p.line(x='timestamp', y=field_name, source=data_source,
-                       legend=legend, line_width=2, line_color=color)
+                if use_step_lines:
+                    p.step(x='timestamp', y=field_name, source=data_source,
+                           legend=legend, line_width=2, line_color=color,
+                           mode="after")
+                else:
+                    p.line(x='timestamp', y=field_name, source=data_source,
+                           legend=legend, line_width=2, line_color=color)
 
         except (KeyError, IndexError, ValueError) as error:
             print(type(error), "("+self._data_name+"):", error)


### PR DESCRIPTION
In case of a slow setpoint updates, rendering a horizontal line is the
correct thing to do, because the controller will keep the setpoint.
However this does not entirely hold if setpoints are logged with lower
rate than what the system actually publishes and uses.

Before:
![bokeh_plot](https://user-images.githubusercontent.com/281593/33657830-c19b41c8-da7a-11e7-8783-5351c56bca45.png)

This PR:
![bokeh_plot 1](https://user-images.githubusercontent.com/281593/33657847-cd708f8a-da7a-11e7-8402-f5f214cc2ce6.png)

(Note: this depends on #73)