### PR TITLE
plots: show flight mode labels when hovering over the plot

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -164,7 +164,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
     data_plot.change_dataset('actuator_controls_0')
     data_plot.add_graph([lambda data: ('thrust', data['control[3]']*100)],
                         colors8[6:7], ['Thrust [0, 100]'])
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
     if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -188,7 +188,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
         data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
                             [color_gray], [axis_name+' Groundtruth'])
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -206,7 +206,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
         data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: (axis+'speed', np.rad2deg(data[axis+'speed']))],
                             [color_gray], [axis_name+' Rate Groundtruth'])
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -222,7 +222,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
         data_plot.change_dataset('vehicle_local_position_setpoint')
         data_plot.add_graph([axis], colors2[1:2], [axis.upper()+' Setpoint'],
                             mark_nan=True, use_step_lines=True)
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -234,7 +234,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                          plot_height='small', changed_params=changed_params,
                          x_range=x_range)
     data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'])
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
     if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -246,7 +246,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'], mark_nan=True)
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         data_plot.change_dataset('vehicle_local_position_groundtruth')
         data_plot.add_graph(['x', 'y', 'z'], colors8[2:5],
@@ -261,7 +261,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'], mark_nan=True)
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         data_plot.change_dataset('vehicle_local_position_groundtruth')
         data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5],
@@ -279,7 +279,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                              lambda data: ('pitch', np.rad2deg(data['pitch'])),
                              lambda data: ('yaw', np.rad2deg(data['yaw']))],
                             colors3, ['Roll', 'Pitch', 'Yaw'], mark_nan=True)
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: ('roll', np.rad2deg(data['roll'])),
@@ -305,7 +305,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
             data_plot.change_dataset('airspeed')
             data_plot.add_graph(['indicated_airspeed_m_s'], colors2[0:1], ['Airspeed Indicated'])
 
-            plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+            plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
             if data_plot.finalize() is not None: plots.append(data_plot)
     except (KeyError, IndexError) as error:
@@ -328,7 +328,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                             ['Y / Roll', 'X / Pitch', 'Yaw', 'Throttle [0, 1]',
                              'Flight Mode', 'Aux1', 'Aux2', 'Kill Switch'])
         # TODO: add RTL switch and others? Look at params which functions are mapped?
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -350,7 +350,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                 legends.append('Channel '+str(i)+' ('+', '.join(channel_names)+')')
         data_plot.add_graph(['channels['+str(i)+']' for i in range(num_rc_channels)],
                             colors8[0:num_rc_channels], legends, mark_nan=True)
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -362,7 +362,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                          changed_params=changed_params, x_range=x_range)
     data_plot.add_graph(['control[0]', 'control[1]', 'control[2]', 'control[3]'],
                         colors8[0:4], ['Roll', 'Pitch', 'Yaw', 'Thrust'], mark_nan=True)
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
     if data_plot.finalize() is not None: plots.append(data_plot)
 
     # actuator controls 1
@@ -373,7 +373,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                          x_range=x_range)
     data_plot.add_graph(['control[0]', 'control[1]', 'control[2]', 'control[3]'],
                         colors8[0:4], ['Roll', 'Pitch', 'Yaw', 'Thrust'], mark_nan=True)
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 
@@ -388,7 +388,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
     data_plot.add_graph(['output['+str(i)+']' for i in
                          range(num_actuator_outputs)], colors8[0:num_actuator_outputs],
                         ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
     if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -412,7 +412,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
         data_plot.add_graph(['output['+str(i)+']' for i in
                              range(num_actuator_outputs)], colors8[0:num_actuator_outputs],
                             ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
-        plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
         if data_plot.finalize() is not None: plots.append(data_plot)
 
@@ -590,7 +590,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data):
                         ['RAM Usage', 'CPU Load'])
     data_plot.add_span('load', line_color=colors3[2])
     data_plot.add_span('ram_usage', line_color=colors3[1])
-    plot_flight_modes_background(data_plot.bokeh_plot, flight_mode_changes, vtol_states)
+    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 


### PR DESCRIPTION
- currently on certain (low quality?) screens, some of the flight mode
  colors are hard to distinguish
- all the Auto modes had only a single color, i.e. it was not possible to
  distinguish between Mission, RTL or Land.

Disadvantage: for certain logs, the plots start to look overloaded.

Examples:

![bokeh_plot 1](https://user-images.githubusercontent.com/281593/34003974-03903980-e0f7-11e7-9fe1-d3414ff4e2a6.png)
![bokeh_plot 2](https://user-images.githubusercontent.com/281593/34003978-08181266-e0f7-11e7-82b2-d8f2d973be97.png)
![bokeh_plot 3](https://user-images.githubusercontent.com/281593/34003991-0c9b4290-e0f7-11e7-9a93-72fc59d2908d.png)
Extreme case:
![bokeh_plot](https://user-images.githubusercontent.com/281593/34004023-1bae0560-e0f7-11e7-9019-94cf710f9910.png)
