### PR TITLE
plot: only plot spectrogram if sampling frequency is higher than 100 Hz

### DIFF
--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -758,57 +758,58 @@ class DataPlotSpec(DataPlot):
 
             if sampling_frequency < 100:
                 self._had_error = True
-            else:
-                field_names_expanded = self._expand_field_names(field_names, data_set)
+                return
 
-                # calculate the spectrogram
-                psd = dict()
-                for key in field_names_expanded:
-                    frequency, time, psd[key] = signal.spectrogram(
-                        data_set[key], fs=sampling_frequency, window=window,
-                        nperseg=window_length, noverlap=noverlap, scaling='density')
+            field_names_expanded = self._expand_field_names(field_names, data_set)
 
-                # sum all psd's
-                key_it = iter(psd)
-                sum_psd = psd[next(key_it)]
-                for key in key_it:
-                    sum_psd += psd[key]
+            # calculate the spectrogram
+            psd = dict()
+            for key in field_names_expanded:
+                frequency, time, psd[key] = signal.spectrogram(
+                    data_set[key], fs=sampling_frequency, window=window,
+                    nperseg=window_length, noverlap=noverlap, scaling='density')
 
-                # offset = int(((1024/2.0)/250.0)*1e6)
-                # scale time to microseconds and add start time as offset
-                time = time * 1.0e6 + self._cur_dataset.data['timestamp'][0]
+            # sum all psd's
+            key_it = iter(psd)
+            sum_psd = psd[next(key_it)]
+            for key in key_it:
+                sum_psd += psd[key]
 
-                color_mapper = LinearColorMapper(palette=viridis(256), low=-80, high=0)
+            # offset = int(((1024/2.0)/250.0)*1e6)
+            # scale time to microseconds and add start time as offset
+            time = time * 1.0e6 + self._cur_dataset.data['timestamp'][0]
 
-                image = [10 * np.log10(sum_psd)]
-                title = self.title
-                for legend in legends:
-                    title += " " + legend
-                title += " [dB]"
+            color_mapper = LinearColorMapper(palette=viridis(256), low=-80, high=0)
 
-                # assume maximal data points per pixel at full resolution
-                max_num_data_points = 2.0*self._config['plot_width']
-                if len(time) > max_num_data_points:
-                    step_size = int(len(time) / max_num_data_points)
-                    time = time[::step_size]
-                    image[0] = image[0][:, ::step_size]
+            image = [10 * np.log10(sum_psd)]
+            title = self.title
+            for legend in legends:
+                title += " " + legend
+            title += " [dB]"
 
-                self._p.y_range = Range1d(frequency[0], frequency[-1])
-                self._p.toolbar_location = 'above'
-                self._p.image(image=image, x=time[0], y=frequency[0], dw=(time[-1]-time[0]),
-                              dh=(frequency[-1]-frequency[0]), color_mapper=color_mapper)
-                color_bar = ColorBar(color_mapper=color_mapper,
-                                     major_label_text_font_size="5pt",
-                                     ticker=BasicTicker(desired_num_ticks=5),
-                                     formatter=PrintfTickFormatter(format="%f"),
-                                     title='[dB]',
-                                     label_standoff=6, border_line_color=None, location=(0, 0))
-                self._p.add_layout(color_bar, 'right')
+            # assume maximal data points per pixel at full resolution
+            max_num_data_points = 2.0*self._config['plot_width']
+            if len(time) > max_num_data_points:
+                step_size = int(len(time) / max_num_data_points)
+                time = time[::step_size]
+                image[0] = image[0][:, ::step_size]
 
-                # add plot zoom tool that only zooms in time axis
-                wheel_zoom = WheelZoomTool()
-                self._p.toolbar.tools = [PanTool(), wheel_zoom, BoxZoomTool(dimensions="width"), ResetTool(), SaveTool()]   # updated_tools
-                self._p.toolbar.active_scroll = wheel_zoom
+            self._p.y_range = Range1d(frequency[0], frequency[-1])
+            self._p.toolbar_location = 'above'
+            self._p.image(image=image, x=time[0], y=frequency[0], dw=(time[-1]-time[0]),
+                          dh=(frequency[-1]-frequency[0]), color_mapper=color_mapper)
+            color_bar = ColorBar(color_mapper=color_mapper,
+                                 major_label_text_font_size="5pt",
+                                 ticker=BasicTicker(desired_num_ticks=5),
+                                 formatter=PrintfTickFormatter(format="%f"),
+                                 title='[dB]',
+                                 label_standoff=6, border_line_color=None, location=(0, 0))
+            self._p.add_layout(color_bar, 'right')
+
+            # add plot zoom tool that only zooms in time axis
+            wheel_zoom = WheelZoomTool()
+            self._p.toolbar.tools = [PanTool(), wheel_zoom, BoxZoomTool(dimensions="width"), ResetTool(), SaveTool()]   # updated_tools
+            self._p.toolbar.active_scroll = wheel_zoom
 
         except (KeyError, IndexError, ValueError, ZeroDivisionError) as error:
             print(type(error), "(" + self._data_name + "):", error)


### PR DESCRIPTION
Spectrogram plots are uninformative and possibly confusing if the sampling rate of the raw acceleration data is low (see issue #75 ). This pull requests removes the spectrogram plot from the plotting page if the raw acceleration data is sampled below 100Hz.

- this pull request resolves issue #75 
- the spectrogram plot is removed from the plotting page by setting its _had_error flag