### PR TITLE
add tooltip to display time with timezone from log

### DIFF
--- a/plot_app/templates/main.js
+++ b/plot_app/templates/main.js
@@ -40,6 +40,7 @@ function showStartLoggingTime() {
 		("0" + d.getHours()).slice(-2) + ":" + ("0" + d.getMinutes()).slice(-2);
 	logging_span.text(date_str);
 	logging_span.show();
+	$('[data-toggle="tooltip"]').tooltip({html: true});
 	// FIXME: yes this is ugly: we check every 500ms for a change. Because there
 	// are some events that lead to a reloading of the DOM elements, which will
 	// reset the logging_span to the hidden state.
@@ -128,7 +129,7 @@ $(function() { //on startup
 
 $(document).ready(function(){
 	// initialize the tooltip's
-	$('[data-toggle="tooltip"]').tooltip();
+	$('[data-toggle="tooltip"]').tooltip({html: true});
 });
 
 /* resize the plots */


### PR DESCRIPTION
@tubeme this correctly shows now 7:46 for the first log in https://github.com/PX4/Firmware/issues/8654:

![flight_review_timezone_tooltip](https://user-images.githubusercontent.com/281593/34882344-98840096-f7b6-11e7-995b-3b456888d5eb.png)

Does that work for you?

Fixes: https://github.com/PX4/flight_review/issues/81