### PR TITLE
Fix search filtered text overflow

### DIFF
--- a/plot_app/templates/browse.html
+++ b/plot_app/templates/browse.html
@@ -67,6 +67,10 @@ $(document).ready(function() {
 			{ "width": "11%" } /* flight modes */
 		],
 
+		"language": {
+			"infoFiltered": "<br>(filtered from _MAX_ total entries)",
+		},
+
 		"serverSide": true,
 		"ajax": "browse_data_retrieval"
 	});


### PR DESCRIPTION
This fixes the following little rendering issue when searching logs. 

#### Before
<img width="1231" alt="screen shot 2018-03-04 at 22 43 12" src="https://user-images.githubusercontent.com/723610/36956652-91d65428-1ffd-11e8-93f5-a3b849531fc6.png">

#### After
<img width="1251" alt="screen shot 2018-03-04 at 22 42 45" src="https://user-images.githubusercontent.com/723610/36956655-971856c0-1ffd-11e8-9528-9ea24d5b4da5.png">

Might not be the best way to fix the issue, especially if you plan on using translations in the future. Other option would be to just set this to `""` or to make the browsing page the same width as the table. I like the latter best.
