### PR TITLE
add meta data filter options to downloading logs script

### DIFF
--- a/config_tables.py
+++ b/config_tables.py
@@ -1,0 +1,45 @@
+
+flight_modes_table = {
+    0: ('Manual', '#cc0000'), # red
+    1: ('Altitude', '#eecc00'), # yellow
+    2: ('Position', '#00cc33'), # green
+    10: ('Acro', '#66cc00'), # olive
+    14: ('Offboard', '#00cccc'), # light blue
+    15: ('Stabilized', '#0033cc'), # dark blue
+    16: ('Rattitude', '#ee9900'), # orange
+
+    # all AUTO-modes use the same color
+    3: ('Mission', '#6600cc'), # purple
+    4: ('Loiter', '#6600cc'), # purple
+    5: ('Return to Land', '#6600cc'), # purple
+    6: ('RC Recovery', '#6600cc'), # purple
+    7: ('Return to groundstation', '#6600cc'), # purple
+    8: ('Land (engine fail)', '#6600cc'), # purple
+    9: ('Land (GPS fail)', '#6600cc'), # purple
+    12: ('Descend', '#6600cc'), # purple
+    13: ('Terminate', '#6600cc'), # purple
+    17: ('Takeoff', '#6600cc'), # purple
+    18: ('Land', '#6600cc'), # purple
+    19: ('Follow Target', '#6600cc'), # purple
+    }
+
+vtol_modes_table = {
+    1: ('Transition', '#cc0000'), # red
+    2: ('Fixed-Wing', '#eecc00'), # yellow
+    3: ('Multicopter', '#0033cc'), # dark blue
+    }
+
+error_labels_table = {
+    # the labels (values) have to be capitalized!
+    # 'validate_error_labels_and_get_ids' will return an error otherwise
+    1: 'Other',
+    2: 'Vibration',
+    3: 'Airframe-design',
+    4: 'Sensor-error',
+    5: 'Component-failure',
+    6: 'Software',
+    7: 'Human-error',
+    8: 'External-conditions'
+       # Note: when adding new labels, always increase the id, never re-use a lower value
+    }
+

--- a/download_logs.py
+++ b/download_logs.py
@@ -4,6 +4,7 @@ import os, glob
 import argparse
 import requests
 from plot_app.config_tables import *
+import datetime
 
 
 def get_arguments():
@@ -92,7 +93,7 @@ def main():
         # filter for rating
         if args.rating is not None:
             rate = [rating.lower() for rating in args.rating]
-            db_entries_list = [entry for entry in db_entries_list if set([entry["rating"].lower()]).issubset(set(rate))]
+            db_entries_list = [entry for entry in db_entries_list if entry["rating"].lower() in rate]
 
         # filter for error labels
         if args.error_labels is not None:
@@ -111,8 +112,9 @@ def main():
         if args.max_num > 0:
             n_en = min(n_en, args.max_num)
 
-        # reverse list order to first download newest log files
-        db_entries_list = [entry for entry in reversed(db_entries_list)]
+        # sort list order to first download the newest log files
+        db_entries_list = sorted(
+            db_entries_list, key=lambda x: datetime.datetime.strptime(x['log_date'], '%Y-%m-%d'), reverse=True)
 
         n_downloaded = 0
         n_skipped = 0

--- a/download_logs.py
+++ b/download_logs.py
@@ -3,7 +3,7 @@
 import os, glob
 import argparse
 import requests
-from config_tables import *
+from plot_app.config_tables import *
 
 
 def get_arguments():
@@ -113,7 +113,6 @@ def main():
         n_downloaded = 0
         n_skipped = 0
 
-        # for i in range(n_en-1, n-1, -1): # -1 because list starts at 0
         for i in range(n_en):
             entry_id = db_entries_list[i]['log_id']
 

--- a/plot_app/config_tables.py
+++ b/plot_app/config_tables.py
@@ -1,3 +1,4 @@
+""" configuration tables """
 
 flight_modes_table = {
     0: ('Manual', '#cc0000'), # red

--- a/plot_app/config_tables.py
+++ b/plot_app/config_tables.py
@@ -1,5 +1,7 @@
 """ configuration tables """
 
+#pylint: disable=invalid-name
+
 flight_modes_table = {
     0: ('Manual', '#cc0000'), # red
     1: ('Altitude', '#eecc00'), # yellow

--- a/plot_app/helper.py
+++ b/plot_app/helper.py
@@ -16,7 +16,7 @@ import numpy as np
 from pyulog import *
 from pyulog.px4 import *
 
-from config import get_log_filepath, get_airframes_filename, get_airframes_url, \
+from .config import get_log_filepath, get_airframes_filename, get_airframes_url, \
                    get_parameters_filename, get_parameters_url, \
                    get_log_cache_size, debug_print_timing, \
                    get_releases_filename
@@ -198,35 +198,6 @@ def get_default_parameters():
             pass
     return param_dict
 
-flight_modes_table = {
-    0: ('Manual', '#cc0000'), # red
-    1: ('Altitude', '#eecc00'), # yellow
-    2: ('Position', '#00cc33'), # green
-    10: ('Acro', '#66cc00'), # olive
-    14: ('Offboard', '#00cccc'), # light blue
-    15: ('Stabilized', '#0033cc'), # dark blue
-    16: ('Rattitude', '#ee9900'), # orange
-
-    # all AUTO-modes use the same color
-    3: ('Mission', '#6600cc'), # purple
-    4: ('Loiter', '#6600cc'), # purple
-    5: ('Return to Land', '#6600cc'), # purple
-    6: ('RC Recovery', '#6600cc'), # purple
-    7: ('Return to groundstation', '#6600cc'), # purple
-    8: ('Land (engine fail)', '#6600cc'), # purple
-    9: ('Land (GPS fail)', '#6600cc'), # purple
-    12: ('Descend', '#6600cc'), # purple
-    13: ('Terminate', '#6600cc'), # purple
-    17: ('Takeoff', '#6600cc'), # purple
-    18: ('Land', '#6600cc'), # purple
-    19: ('Follow Target', '#6600cc'), # purple
-    }
-
-vtol_modes_table = {
-    1: ('Transition', '#cc0000'), # red
-    2: ('Fixed-Wing', '#eecc00'), # yellow
-    3: ('Multicopter', '#0033cc'), # dark blue
-    }
 
 
 def WGS84_to_mercator(lon, lat):
@@ -315,6 +286,7 @@ class ULogException(Exception):
     pass
 
 @lru_cache(maxsize=get_log_cache_size())
+
 def load_ulog_file(file_name):
     """ load an ULog file
     :return: ULog object
@@ -421,20 +393,6 @@ def print_cache_info():
 def clear_ulog_cache():
     """ clear/invalidate the ulog cache """
     load_ulog_file.cache_clear()
-
-error_labels_table = {
-    # the labels (values) have to be capitalized!
-    # 'validate_error_labels_and_get_ids' will return an error otherwise
-    1: 'Other',
-    2: 'Vibration',
-    3: 'Airframe-design',
-    4: 'Sensor-error',
-    5: 'Component-failure',
-    6: 'Software',
-    7: 'Human-error',
-    8: 'External-conditions'
-       # Note: when adding new labels, always increase the id, never re-use a lower value
-    }
 
 def validate_error_ids(err_ids):
     """

--- a/plot_app/helper.py
+++ b/plot_app/helper.py
@@ -16,7 +16,8 @@ import numpy as np
 from pyulog import *
 from pyulog.px4 import *
 
-from .config import get_log_filepath, get_airframes_filename, get_airframes_url, \
+from config_tables import *
+from config import get_log_filepath, get_airframes_filename, get_airframes_url, \
                    get_parameters_filename, get_parameters_url, \
                    get_log_cache_size, debug_print_timing, \
                    get_releases_filename
@@ -198,8 +199,6 @@ def get_default_parameters():
             pass
     return param_dict
 
-
-
 def WGS84_to_mercator(lon, lat):
     """ Convert lon, lat in [deg] to Mercator projection """
 # alternative that relies on the pyproj library:
@@ -286,7 +285,6 @@ class ULogException(Exception):
     pass
 
 @lru_cache(maxsize=get_log_cache_size())
-
 def load_ulog_file(file_name):
     """ load an ULog file
     :return: ULog object


### PR DESCRIPTION
This pull request extends the download_logs script by command line arguments for filtering the database before downloading files.

- new arguments are added for filtering by mav type, flight modes, error labels and rating
- the flight mode and error label tables are moved from helper.py to a separate file config_tables.py
- The filters modify the db_entries_list to only download the types specified
- the list order is reversed to first download the newest data
