### PR TITLE
Add actuator controls FFT plot

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -375,6 +375,24 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
     plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
     if data_plot.finalize() is not None: plots.append(data_plot)
 
+    # actuator controls (Main) FFT (for filter & output noise analysis)
+    data_plot = DataPlotFFT(data, plot_config, 'actuator_controls_0',
+                            title='Actuator Controls FFT')
+    data_plot.add_graph(['control[0]', 'control[1]', 'control[2]'],
+                        colors3, ['Roll', 'Pitch', 'Yaw'])
+    if not data_plot.had_error:
+        if 'MC_DTERM_CUTOFF' in ulog.initial_parameters:
+            data_plot.mark_frequency(
+                ulog.initial_parameters['MC_DTERM_CUTOFF'],
+                'MC_DTERM_CUTOFF')
+        if 'IMU_GYRO_CUTOFF' in ulog.initial_parameters:
+            data_plot.mark_frequency(
+                ulog.initial_parameters['IMU_GYRO_CUTOFF'],
+                'IMU_GYRO_CUTOFF', 20)
+
+    if data_plot.finalize() is not None: plots.append(data_plot)
+
+
     # actuator controls 1
     # (only present on VTOL, Fixed-wing config)
     data_plot = DataPlot(data, plot_config, 'actuator_controls_1',

--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -396,7 +396,7 @@ class DataPlot:
 
             if changed_params is not None:
                 self._param_change_label = \
-                    plot_parameter_changes(self._p, config['plot_height'][plot_height],
+                    plot_parameter_changes(self._p, self.plot_height,
                                            changed_params)
 
             self._cur_dataset = [elem for elem in data
@@ -602,7 +602,7 @@ class DataPlot:
 
     def _setup_plot(self):
         plots_width = self._config['plot_width']
-        plots_height = self._config['plot_height'][self._plot_height_name]
+        plots_height = self.plot_height
         p = self._p
 
         p.plot_width = plots_width


### PR DESCRIPTION
Should be useful for filter tuning and noise analysis. Requires high rate logging to be enabled in order for the plot to show up.

Example with different d-term cutoff frequencies:
d-term cutoff = 50:
![bokeh_plot 2](https://user-images.githubusercontent.com/281593/39427306-96521bb0-4c83-11e8-80d4-4e2d06cb02a5.png)
d-term cutoff = 70: noise a bit increased, but still flies well:
![bokeh_plot 1](https://user-images.githubusercontent.com/281593/39427406-e2eb0324-4c83-11e8-86b9-0a163436a479.png)
d-term cutoff = 80: noticeable more noise, affecting flight performance:
![bokeh_plot](https://user-images.githubusercontent.com/281593/39427404-deb911f6-4c83-11e8-8a09-1bd7ebab11d2.png)

Here's another interesting example:
![imu_cutoff_100_dterm_80__actuator_controls_fft](https://user-images.githubusercontent.com/281593/39427420-f19dc3ac-4c83-11e8-88fe-6074feb43676.png)
![imu_cutoff_100_dterm_60__actuator_controls_fft](https://user-images.githubusercontent.com/281593/39427430-f7780a44-4c83-11e8-812e-80b6e17a8e2b.png)
Decreasing the d-term cutoff lead to an increase of the lower frequencies. I think it's because the D gain is a bit too high together with increased latency of the D-term signal.

@RomanBapst @MaEtUgR 