### PR TITLE
fix FFT performance: use fftw instead of scipy.fft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-    - "sudo apt-get install sqlite3"
-    - "pip install bokeh jinja2 pyulog scipy"
+    - "sudo apt-get install sqlite3 fftw3 libfftw3-dev"
+    - "pip install bokeh jinja2 pyulog scipy pyfftw"
     - "pip install requests pylint"
 # command to run code checks
 script: ./run_pylint.sh

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Flight Review is deployed at https://review.px4.io.
 
 - clone the repository
 - use python3
-- `pip3 install bokeh jinja2 pyulog simplekml scipy` (at least version 0.12.11
-  of bokeh is required)
-- `sudo apt-get install sqlite3`
+- `sudo apt-get install sqlite3 fftw3 libfftw3-dev`
+- `pip3 install bokeh jinja2 pyulog simplekml scipy pyfftw`
+  (at least version 0.12.11 of bokeh is required)
 - configure web server config (this can be skipped for a local installation):
   create a file `config_user.ini` and copy and adjust the sections and values
   from `config_default.ini` that should be overridden.

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -27,7 +27,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
     data = ulog.data_list
 
     # COMPATIBILITY support for old logs
-    if any(elem.name == 'vehicle_air_data' for elem in data):
+    if any(elem.name == 'vehicle_air_data' or elem.name == 'vehicle_magnetometer' for elem in data):
         baro_alt_meter_topic = 'vehicle_air_data'
         magnetometer_ga_topic = 'vehicle_magnetometer'
     else: # old


### PR DESCRIPTION
scipy.fft becomes slow for input lengths that factorize into large primes. It runs with O(N^2) for prime lengths.

In some cases the page loading timed out because of this (FFT plots are only shown for logs with the high-rate logging profile active).