### PR TITLE
dbinfo api: add vehicle name, airframe name & type to list returned from get request

### DIFF
--- a/download_logs.py
+++ b/download_logs.py
@@ -42,6 +42,12 @@ def get_arguments():
                         help='Filter logs by rating. e.g. Good')
     parser.add_argument('--uuid', default=None, type=str,
                         help='Filter logs by a particular vehicle uuid. e.g. 0123456789')
+    parser.add_argument('--vehicle-name', default=None, type=str,
+                        help='Filter logs by a particular vehicle name.')
+    parser.add_argument('--airframe-name', default=None, type=str,
+                        help='Filter logs by a particular airframe name. e.g. Generic Quadrotor X')
+    parser.add_argument('--airframe-type', default=None, type=str,
+                        help='Filter logs by a particular airframe type. e.g. Quadrotor X')
     return parser.parse_args()
 
 
@@ -120,6 +126,21 @@ def main():
         if args.uuid is not None:
             db_entries_list = [
                 entry for entry in db_entries_list if entry['vehicle_uuid'] == args.uuid]
+
+        # filter for vehicle name
+        if args.vehicle_name is not None:
+            db_entries_list = [
+                entry for entry in db_entries_list if entry['vehicle_name'] == args.vehicle_name]
+
+        # filter for airframe name
+        if args.airframe_name is not None:
+            db_entries_list = [
+                entry for entry in db_entries_list if entry['airframe_name'] == args.airframe_name]
+
+        # filter for airframe type
+        if args.airframe_type is not None:
+            db_entries_list = [
+                entry for entry in db_entries_list if entry['airframe_type'] == args.airframe_type]
 
         # set number of files to download
         n_en = len(db_entries_list)

--- a/tornado_handlers/db_info_json.py
+++ b/tornado_handlers/db_info_json.py
@@ -63,8 +63,7 @@ class DBInfoHandler(tornado.web.RequestHandler):
 
             jsondict.update(db_data_gen.to_json_dict())
             # add vehicle name
-            jsondict['vehicle_name'] = vehicle_table[jsondict['vehicle_uuid']] \
-                if jsondict['vehicle_uuid'] in vehicle_table else ''
+            jsondict['vehicle_name'] = vehicle_table.get(jsondict['vehicle_uuid'], '')
             airframe_data = get_airframe_data(jsondict['sys_autostart_id'])
             jsondict['airframe_name'] = airframe_data.get('name', '')
             jsondict['airframe_type'] = airframe_data.get('type', jsondict['sys_autostart_id'])


### PR DESCRIPTION
this pr adds new fields (vehicle name, airframe name, airframe type) to the db entries list generated by the dbinfo api and adds these fields as filters for the download_logs script. 

- db_info_json: extract the vehicle name from the vehicles db and
generate the aiframe name and type; store them in json dictionary
returned by the dbinfo request
- download_logs: enable filtering by vehicle-name, airframe-name,
and airframe-type