### PR TITLE
More readable angular plots with np.unwrap()

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -188,11 +188,11 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
                              y_axis_label='[deg]', title=axis_name+' Angle',
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
-        data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
+        data_plot.add_graph([lambda data: (axis, np.rad2deg(np.unwrap(data[axis])))],
                             colors3[0:1], [axis_name+' Estimated'], mark_nan=True)
         data_plot.change_dataset('vehicle_attitude_setpoint')
         # in fixed-wing, the attitude setpoint is allowed to be NaN
-        data_plot.add_graph([lambda data: (axis+'_d', np.rad2deg(data[axis+'_d']))],
+        data_plot.add_graph([lambda data: (axis+'_d', np.rad2deg(np.unwrap(data[axis+'_d'])))],
                             colors3[1:2], [axis_name+' Setpoint'],
                             mark_nan=is_multicopter, use_step_lines=True)
         if axis == 'yaw':


### PR DESCRIPTION
Attitude plots (Roll Angle, Pitch Angle, Yaw Angle) are wrapped from -180° to 180°.
This causes poor plots, with weird "jumps", when the drone passes the 180° threshold, e.g., by oscillating in yaw around 180°:

![Yaw angle is jumping](https://user-images.githubusercontent.com/5058646/48312024-ed1a7280-e5a8-11e8-9043-b302159546f1.png)

By using the [numpy.unwrap()](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.unwrap.html) method, we can avoid those jumps and obtain a more continuous graph. The following example is the same plot as before, with the patch applied:

![With np.unwrap()](https://user-images.githubusercontent.com/5058646/48312028-15a26c80-e5a9-11e8-8fac-7c3d044a5730.png)
