### PR TITLE
Fix: Rename groundtruth topics

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -134,7 +134,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
         data_plot.change_dataset('vehicle_local_position_setpoint')
         data_plot.add_graph('y', 'x', colors2[1], 'Setpoint')
         # groundtruth (SITL only)
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_local_position_groundtruth')
         data_plot.add_graph('y', 'x', color_gray, 'Groundtruth')
         # GPS + position setpoints
         plot_map(ulog, plot_config, map_type='plain', setpoints=True,
@@ -200,7 +200,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
                 [lambda data: ('yaw_sp_move_rate', np.rad2deg(data['yaw_sp_move_rate']))],
                 colors3[2:3], [axis_name+' FF Setpoint [deg/s]'],
                 use_step_lines=True)
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
                             [color_gray], [axis_name+' Groundtruth'])
         plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
@@ -228,7 +228,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
         data_plot.change_dataset('rate_ctrl_status')
         data_plot.add_graph([lambda data: (axis, data[axis+'speed_integ']*100)],
                             colors3[2:3], [axis_name+' Rate Integral '+rate_int_limit])
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: (axis+'speed', np.rad2deg(data[axis+'speed']))],
                             [color_gray], [axis_name+' Rate Groundtruth'])
         plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
@@ -277,7 +277,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
         data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'], mark_nan=True)
         plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_local_position_groundtruth')
         data_plot.add_graph(['x', 'y', 'z'], colors8[2:5],
                             ['Groundtruth X', 'Groundtruth Y', 'Groundtruth Z'])
 
@@ -292,7 +292,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
         data_plot.add_graph(['vx', 'vy', 'vz'], colors3, ['X', 'Y', 'Z'], mark_nan=True)
         plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_local_position_groundtruth')
         data_plot.add_graph(['vx', 'vy', 'vz'], colors8[2:5],
                             ['Groundtruth VX', 'Groundtruth VY', 'Groundtruth VZ'])
         if data_plot.finalize() is not None: plots.append(data_plot)
@@ -309,7 +309,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
                             colors3, ['Roll', 'Pitch', 'Yaw'], mark_nan=True)
         plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: ('roll', np.rad2deg(data['roll'])),
                              lambda data: ('pitch', np.rad2deg(data['pitch'])),
                              lambda data: ('yaw', np.rad2deg(data['yaw']))],
@@ -327,7 +327,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page):
                             colors3, ['Roll Rate', 'Pitch Rate', 'Yaw Rate'], mark_nan=True)
         plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
-        data_plot.change_dataset('vehicle_groundtruth')
+        data_plot.change_dataset('vehicle_attitude_groundtruth')
         data_plot.add_graph([lambda data: ('rollspeed', np.rad2deg(data['rollspeed'])),
                              lambda data: ('pitchspeed', np.rad2deg(data['pitchspeed'])),
                              lambda data: ('yawspeed', np.rad2deg(data['yawspeed']))],

--- a/plot_app/helper.py
+++ b/plot_app/helper.py
@@ -301,10 +301,11 @@ def load_ulog_file(file_name):
                   'actuator_controls_1', 'actuator_outputs',
                   'vehicle_attitude', 'vehicle_attitude_setpoint',
                   'vehicle_rates_setpoint', 'rc_channels', 'input_rc',
-                  'position_setpoint_triplet', 'vehicle_groundtruth',
-                  'vehicle_visual_odometry', 'vehicle_status', 'airspeed',
-                  'manual_control_setpoint', 'rate_ctrl_status',
-                  'vehicle_air_data', 'vehicle_magnetometer', 'system_power']
+                  'position_setpoint_triplet', 'vehicle_attitude_groundtruth',
+                  'vehicle_local_position_groundtruth', 'vehicle_visual_odometry',
+                  'vehicle_status', 'airspeed', 'manual_control_setpoint',
+                  'rate_ctrl_status', 'vehicle_air_data',
+                  'vehicle_magnetometer', 'system_power']
     try:
         ulog = ULog(file_name, msg_filter)
     except FileNotFoundError:


### PR DESCRIPTION
#111 changes were meant to address PX4/Firmware#9301, which was replaced by PX4/Firmware#9895. This is rollback  to #111 to the have the correct groundtruth topics plotted.