### PR TITLE
plot page: add link to https://docs.px4.io/en/log/flight_review.html

### DIFF
--- a/plot_app/templates/index.html
+++ b/plot_app/templates/index.html
@@ -3,6 +3,10 @@
 
 
 {% if not internal_error %}
+<div class="alert alert-primary"> <!-- alternatives: alert-info, alert-primary, alert-secondary -->
+  Do you need help with interpreting the plots?
+  See <a href="https://docs.px4.io/en/log/flight_review.html" target="_blank" class="alert-link">here</a>.
+</div>
 
 {{ title_html }}
 {{ hardfault_html }}


### PR DESCRIPTION
This is on purpose quite prominent, so that users don't miss it.
We can reduce that in future.

![screenshot_20181119_115209](https://user-images.githubusercontent.com/281593/48702603-98eb4000-ebf1-11e8-9e56-452a69fa5fd3.png)
