### PR TITLE
remove CI logs from logs list in browse page

### DIFF
--- a/plot_app/statistics_plots.py
+++ b/plot_app/statistics_plots.py
@@ -129,7 +129,10 @@ class StatisticsPlots:
 
                 self._all_logs_dates.append(log.date)
                 if log.is_public == 1:
-                    self._public_logs_dates.append(log.date)
+                    if log.source == 'CI':
+                        self._ci_logs_dates.append(log.date)
+                    else:
+                        self._public_logs_dates.append(log.date)
                 else:
                     if log.source == 'CI':
                         self._ci_logs_dates.append(log.date)
@@ -138,7 +141,7 @@ class StatisticsPlots:
 
 
                 # LogsGenerated: public only
-                if log.is_public != 1:
+                if log.is_public != 1 or log.source == 'CI':
                     continue
 
                 cur.execute('select * from LogsGenerated where Id = ?', [log.log_id])

--- a/tornado_handlers/browse.py
+++ b/tornado_handlers/browse.py
@@ -69,7 +69,7 @@ class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
                     '       LogsGenerated.* '
                     'FROM Logs '
                     '   LEFT JOIN LogsGenerated on Logs.Id=LogsGenerated.Id '
-                    'WHERE Logs.Public = 1 '
+                    'WHERE Logs.Public = 1 AND NOT Logs.Source = "CI" '
                     +sql_order)
 
         # pylint: disable=invalid-name


### PR DESCRIPTION
this pull request removes CI logs from the logs list in the browse page. with this pr PX4 Firmware CI logs may be uploaded as public without cluttering the flight log list.