### PR TITLE
fixed reference to scipy.signal.spectrogram

### DIFF
--- a/testing_notebook.ipynb
+++ b/testing_notebook.ipynb
@@ -285,7 +285,7 @@
     "# calculate the spectogram\n",
     "psd = dict()\n",
     "for key, val in data_set.items():\n",
-    "    f, t, psd[key] = signal.spectrogram(\n",
+    "    f, t, psd[key] = scipy.signal.spectrogram(\n",
     "        val,fs=fs, window=window, nperseg=window_length, noverlap=noverlap, scaling='density')\n",
     "    \n",
     "# sum all psd's\n",


### PR DESCRIPTION
Added missing scipy. prefix.