### PR TITLE
Vibration metrics plot

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -662,7 +662,24 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                          'accelerometer_m_s2[2]'], colors3, ['X', 'Y', 'Z'])
     if data_plot.finalize() is not None: plots.append(data_plot)
 
+    # Vibration Metrics
+    data_plot = DataPlot(data, plot_config, 'estimator_status',
+                         title='Vibration Metrics',
+                         plot_height='small', changed_params=changed_params,
+                         x_range=x_range, y_start=0)
+    data_plot.add_graph(['vibe[2]'], colors3[2:3], ['Delta Velocity Vibration Level [m/s]'])
+    data_plot.add_horizontal_background_boxes(
+        ['green', 'orange', 'red'], [0.02, 0.04])
 
+    if data_plot.finalize() is not None: plots.append(data_plot)
+
+    # Acceleration Spectrogram
+    data_plot = DataPlotSpec(data, plot_config, 'sensor_combined',
+                             y_axis_label='[Hz]', title='Acceleration Power Spectral Density',
+                             plot_height='small', x_range=x_range)
+    data_plot.add_graph(['accelerometer_m_s2[0]', 'accelerometer_m_s2[1]', 'accelerometer_m_s2[2]'],
+                        ['X', 'Y', 'Z'])
+    if data_plot.finalize() is not None: plots.append(data_plot)
 
     # raw angular speed
     data_plot = DataPlot(data, plot_config, 'sensor_combined',
@@ -675,7 +692,6 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
         lambda data: ('gyro_rad[2]', np.rad2deg(data['gyro_rad[2]']))],
                         colors3, ['X', 'Y', 'Z'])
     if data_plot.finalize() is not None: plots.append(data_plot)
-
 
 
     # magnetic field strength
@@ -742,13 +758,6 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
     if data_plot.finalize() is not None: plots.append(data_plot)
 
 
-    # Acceleration Spectrogram
-    data_plot = DataPlotSpec(data, plot_config, 'sensor_combined',
-                             y_axis_label='[Hz]', title='Acceleration Power Spectral Density',
-                             plot_height='small', x_range=x_range)
-    data_plot.add_graph(['accelerometer_m_s2[0]', 'accelerometer_m_s2[1]', 'accelerometer_m_s2[2]'],
-                        ['X', 'Y', 'Z'])
-    if data_plot.finalize() is not None: plots.append(data_plot)
 
     # power
     data_plot = DataPlot(data, plot_config, 'battery_status',

--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -589,6 +589,19 @@ class DataPlot:
             print(type(error), "("+self._data_name+"):", error)
             self._had_error = True
 
+    def add_horizontal_background_boxes(self, colors, limits):
+        """ Add horizontal background boxes filled with a color
+            :param colors: list of N colors (in increasing y direction)
+            :param limits: list of N-1 y-axis values
+        """
+        bottom = None
+        limits.append(None)
+        for color, limit in zip(colors, limits):
+            self._p.add_layout(BoxAnnotation(
+                bottom=bottom, top=limit, fill_alpha=0.09, line_alpha=1,
+                fill_color=color, line_width=0))
+            bottom = limit
+
     def set_use_time_formatter(self, use_formatter):
         """ configure whether the time formatter should be used """
         self._use_time_formatter = use_formatter

--- a/plot_app/plotting.py
+++ b/plot_app/plotting.py
@@ -92,7 +92,6 @@ def plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states=Non
     if vtol_states is not None:
         added_box_annotation_args['bottom'] = vtol_state_height
         added_box_annotation_args['bottom_units'] = 'screen'
-    annotations = []
     labels_y_pos = []
     labels_x_pos = []
     labels_text = []
@@ -111,7 +110,6 @@ def plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states=Non
                                        fill_alpha=0.09, line_color=None,
                                        fill_color=color,
                                        **added_box_annotation_args)
-            annotations.append(annotation)
             p.add_layout(annotation)
 
             if flight_mode_changes[i+1][0] - t_start > 1e6: # filter fast


### PR DESCRIPTION
Since EKF2 already provides a metric, we can just plot it. The last one based on accel is the most useful.

Examples:
![bokeh_plot(1)](https://user-images.githubusercontent.com/281593/66331559-297a5e00-e933-11e9-95c0-b11eee94e462.png)
![bokeh_plot](https://user-images.githubusercontent.com/281593/66331567-2da67b80-e933-11e9-8a41-340c7c2da030.png)
![bokeh_plot(2)](https://user-images.githubusercontent.com/281593/66331578-31d29900-e933-11e9-9574-8a1109c55d22.png)

The background color is an indicator for how good it is: preferably everything should be below 0.02. I tested this on a bunch of logs and the levels seem reasonable, but can be adjusted if needed.
The levels are also in agreement with the thresholds of the [ekf analysis tools](https://github.com/PX4/Firmware/tree/master/Tools/ecl_ekf).
It can be extended to do threshold checking and show warnings if thresholds are exceeded.