### PR TITLE
scipy>1.3.3 breaks the fft import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pyfftw
 pylint
 pyulog
 requests
-scipy
+scipy==1.3.3
 simplekml
 smopy


### PR DESCRIPTION
Scipy version 1.4.x breaks the fft import in plotting.py for the wrapper pyfftw.
scipy.fftpack has been deprecated and is treated as legacy. Until a permanent change, this is a good temporary fix.