### PR TITLE
Airspeed plot: display TAS instead of EAS and adapt to latest px4 conventions

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -45,6 +45,11 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                 topic.data['sensors3v3[0]'] = topic.data.pop('voltage3V3_v')
             if 'voltage3v3_v' in topic.data:
                 topic.data['sensors3v3[0]'] = topic.data.pop('voltage3v3_v')
+        if topic.name == 'tecs_status':
+            if 'true_airspeed_sp' in topic.data:
+                tecs_true_airspeed_sp_message = 'true_airspeed_sp'
+            else:
+                tecs_true_airspeed_sp_message = 'airspeed_sp'
 
     if any(elem.name == 'vehicle_angular_velocity' for elem in data):
         rate_estimated_topic_name = 'vehicle_angular_velocity'
@@ -364,11 +369,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
             data_plot.change_dataset('vehicle_gps_position')
             data_plot.add_graph(['vel_m_s'], colors8[2:3], ['Ground Speed (from GPS)'])
             data_plot.change_dataset('tecs_status')
-            if 'true_airspeed_sp' in cur_dataset.data:
-                data_plot.add_graph(['true_airspeed_sp'], colors8[3:4], ['True Airspeed Setpoint'])
-            else:
-                data_plot.add_graph(['airspeed_sp'], colors8[3:4], ['True Airspeed Setpoint'])
-
+            data_plot.add_graph([tecs_true_airspeed_sp_message], colors8[3:4], ['True Airspeed Setpoint'])
             plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
             if data_plot.finalize() is not None: plots.append(data_plot)

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -352,11 +352,11 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                 airspeed_validated = ulog.get_dataset('airspeed_validated')
                 data_plot.change_dataset('airspeed_validated')
                 if np.amax(airspeed_validated.data['airspeed_sensor_measurement_valid']) == 1:
-                    data_plot.add_graph(['equivalent_airspeed_m_s'], colors8[1:2],
-                                        ['Equivalent Airspeed'])
+                    data_plot.add_graph(['true_airspeed_m_s'], colors8[1:2],
+                                        ['True Airspeed'])
                 else:
-                    data_plot.add_graph(['equivalent_ground_minus_wind_m_s'], colors8[1:2],
-                                        ['Ground Minus Wind'])
+                    data_plot.add_graph(['true_ground_minus_wind_m_s'], colors8[1:2],
+                                        ['True Airspeed (estimated)'])
             else:
                 data_plot.change_dataset('airspeed')
                 data_plot.add_graph(['indicated_airspeed_m_s'], colors8[1:2],
@@ -364,7 +364,10 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
             data_plot.change_dataset('vehicle_gps_position')
             data_plot.add_graph(['vel_m_s'], colors8[2:3], ['Ground Speed (from GPS)'])
             data_plot.change_dataset('tecs_status')
-            data_plot.add_graph(['airspeed_sp'], colors8[3:4], ['Airspeed Setpoint'])
+            if 'true_airspeed_sp' in cur_dataset.data:
+                data_plot.add_graph(['true_airspeed_sp'], colors8[3:4], ['True Airspeed Setpoint'])
+            else:
+                data_plot.add_graph(['airspeed_sp'], colors8[3:4], ['True Airspeed Setpoint'])
 
             plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 


### PR DESCRIPTION
-  since https://github.com/PX4/PX4-Autopilot/pull/16585, tecs_status.airspeed_sp got renamed to tecs_status.true_airspeed_sp
- EAS got renames to CAS --> I think though that it anyway is more useful to display TAS (true airspeed) in the Airspeed plot, as that's the one you can compare to groundspeed


![image](https://user-images.githubusercontent.com/26798987/105717377-57b4f000-5f20-11eb-8743-a4c0085562ce.png)
