### PR TITLE
Add plot for third instance of actuator_outputs.

### DIFF
--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -470,12 +470,14 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
     plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
     if data_plot.finalize() is not None: plots.append(data_plot)
 
-    actuator_output_plots = [(0, "Actuator Outputs (Main)"), (1, "Actuator Outputs (AUX)"), (2, "Actuator Outputs (EXTRA)")]
+    actuator_output_plots = [(0, "Actuator Outputs (Main)"), (1, "Actuator Outputs (AUX)"),
+                             (2, "Actuator Outputs (EXTRA)")]
     for topic_instance, plot_name in actuator_output_plots:
 
         data_plot = DataPlot(data, plot_config, 'actuator_outputs',
-                            y_start=0, title=plot_name, plot_height='small',
-                            changed_params=changed_params, topic_instance=topic_instance, x_range=x_range)
+                             y_start=0, title=plot_name, plot_height='small',
+                             changed_params=changed_params, topic_instance=topic_instance,
+                             x_range=x_range)
         num_actuator_outputs = 16
         # only plot if at least one of the outputs is not constant
         all_constant = True
@@ -483,14 +485,16 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
             max_outputs = np.amax(data_plot.dataset.data['noutputs'])
             if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
 
-        for i in range(num_actuator_outputs):
+            for i in range(num_actuator_outputs):
                 output_data = data_plot.dataset.data['output['+str(i)+']']
                 if not np.all(output_data == output_data[0]):
                     all_constant = False
+
         if not all_constant:
             data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
                                 [colors8[i % 8] for i in range(num_actuator_outputs)],
-                                ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
+                                ['Output '+str(i) for i in range(num_actuator_outputs)],
+                                mark_nan=True)
             plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
             if data_plot.finalize() is not None: plots.append(data_plot)

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -476,20 +476,53 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                          y_start=0, title='Actuator Outputs (Main)', plot_height='small',
                          changed_params=changed_params, x_range=x_range)
     num_actuator_outputs = 16
+    # only plot if at least one of the outputs is not constant
+    all_constant = True
     if data_plot.dataset:
         max_outputs = np.amax(data_plot.dataset.data['noutputs'])
         if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
-    data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
-                        [colors8[i % 8] for i in range(num_actuator_outputs)],
-                        ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
-    plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
-    if data_plot.finalize() is not None: plots.append(data_plot)
+    for i in range(num_actuator_outputs):
+            output_data = data_plot.dataset.data['output['+str(i)+']']
+            if not np.all(output_data == output_data[0]):
+                all_constant = False
+    if not all_constant:
+        data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
+                            [colors8[i % 8] for i in range(num_actuator_outputs)],
+                            ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
+
+        if data_plot.finalize() is not None: plots.append(data_plot)
 
     # actuator outputs 1: AUX
     data_plot = DataPlot(data, plot_config, 'actuator_outputs',
                          y_start=0, title='Actuator Outputs (AUX)', plot_height='small',
                          changed_params=changed_params, topic_instance=1,
+                         x_range=x_range)
+    num_actuator_outputs = 16
+    # only plot if at least one of the outputs is not constant
+    all_constant = True
+    if data_plot.dataset:
+        max_outputs = np.amax(data_plot.dataset.data['noutputs'])
+        if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
+
+        for i in range(num_actuator_outputs):
+            output_data = data_plot.dataset.data['output['+str(i)+']']
+            if not np.all(output_data == output_data[0]):
+                all_constant = False
+    if not all_constant:
+        data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
+                            [colors8[i % 8] for i in range(num_actuator_outputs)],
+                            ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
+        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
+
+        if data_plot.finalize() is not None: plots.append(data_plot)
+
+
+    # actuator outputs 2: EXTRA
+    data_plot = DataPlot(data, plot_config, 'actuator_outputs',
+                         y_start=0, title='Actuator Outputs (EXTRA)', plot_height='small',
+                         changed_params=changed_params, topic_instance=2,
                          x_range=x_range)
     num_actuator_outputs = 16
     # only plot if at least one of the outputs is not constant

--- a/plot_app/configured_plots.py
+++ b/plot_app/configured_plots.py
@@ -470,79 +470,30 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
     plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
     if data_plot.finalize() is not None: plots.append(data_plot)
 
+    actuator_output_plots = [(0, "Actuator Outputs (Main)"), (1, "Actuator Outputs (AUX)"), (2, "Actuator Outputs (EXTRA)")]
+    for topic_instance, plot_name in actuator_output_plots:
 
-    # actuator outputs 0: Main
-    data_plot = DataPlot(data, plot_config, 'actuator_outputs',
-                         y_start=0, title='Actuator Outputs (Main)', plot_height='small',
-                         changed_params=changed_params, x_range=x_range)
-    num_actuator_outputs = 16
-    # only plot if at least one of the outputs is not constant
-    all_constant = True
-    if data_plot.dataset:
-        max_outputs = np.amax(data_plot.dataset.data['noutputs'])
-        if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
-
-    for i in range(num_actuator_outputs):
-            output_data = data_plot.dataset.data['output['+str(i)+']']
-            if not np.all(output_data == output_data[0]):
-                all_constant = False
-    if not all_constant:
-        data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
-                            [colors8[i % 8] for i in range(num_actuator_outputs)],
-                            ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
-        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
-
-        if data_plot.finalize() is not None: plots.append(data_plot)
-
-    # actuator outputs 1: AUX
-    data_plot = DataPlot(data, plot_config, 'actuator_outputs',
-                         y_start=0, title='Actuator Outputs (AUX)', plot_height='small',
-                         changed_params=changed_params, topic_instance=1,
-                         x_range=x_range)
-    num_actuator_outputs = 16
-    # only plot if at least one of the outputs is not constant
-    all_constant = True
-    if data_plot.dataset:
-        max_outputs = np.amax(data_plot.dataset.data['noutputs'])
-        if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
+        data_plot = DataPlot(data, plot_config, 'actuator_outputs',
+                            y_start=0, title=plot_name, plot_height='small',
+                            changed_params=changed_params, topic_instance=topic_instance, x_range=x_range)
+        num_actuator_outputs = 16
+        # only plot if at least one of the outputs is not constant
+        all_constant = True
+        if data_plot.dataset:
+            max_outputs = np.amax(data_plot.dataset.data['noutputs'])
+            if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
 
         for i in range(num_actuator_outputs):
-            output_data = data_plot.dataset.data['output['+str(i)+']']
-            if not np.all(output_data == output_data[0]):
-                all_constant = False
-    if not all_constant:
-        data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
-                            [colors8[i % 8] for i in range(num_actuator_outputs)],
-                            ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
-        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
+                output_data = data_plot.dataset.data['output['+str(i)+']']
+                if not np.all(output_data == output_data[0]):
+                    all_constant = False
+        if not all_constant:
+            data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
+                                [colors8[i % 8] for i in range(num_actuator_outputs)],
+                                ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
+            plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
 
-        if data_plot.finalize() is not None: plots.append(data_plot)
-
-
-    # actuator outputs 2: EXTRA
-    data_plot = DataPlot(data, plot_config, 'actuator_outputs',
-                         y_start=0, title='Actuator Outputs (EXTRA)', plot_height='small',
-                         changed_params=changed_params, topic_instance=2,
-                         x_range=x_range)
-    num_actuator_outputs = 16
-    # only plot if at least one of the outputs is not constant
-    all_constant = True
-    if data_plot.dataset:
-        max_outputs = np.amax(data_plot.dataset.data['noutputs'])
-        if max_outputs < num_actuator_outputs: num_actuator_outputs = max_outputs
-
-        for i in range(num_actuator_outputs):
-            output_data = data_plot.dataset.data['output['+str(i)+']']
-            if not np.all(output_data == output_data[0]):
-                all_constant = False
-    if not all_constant:
-        data_plot.add_graph(['output['+str(i)+']' for i in range(num_actuator_outputs)],
-                            [colors8[i % 8] for i in range(num_actuator_outputs)],
-                            ['Output '+str(i) for i in range(num_actuator_outputs)], mark_nan=True)
-        plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states)
-
-        if data_plot.finalize() is not None: plots.append(data_plot)
-
+            if data_plot.finalize() is not None: plots.append(data_plot)
 
     # raw acceleration
     data_plot = DataPlot(data, plot_config, 'sensor_combined',


### PR DESCRIPTION
Currently when flying a vehicle that has an AUX mixer + also has UAVCAN ESCs the motors for the plots will not be plotted as they fall into `actuator_outputs.02`. This fixes that. It also removes `actuator_outputs.00` when this one is empty (which happens in the aforementioned case).

Current:

![image](https://user-images.githubusercontent.com/11491719/106019519-085af500-60c3-11eb-991e-b0880c081084.png)

Fixed:

![image](https://user-images.githubusercontent.com/11491719/106019575-16107a80-60c3-11eb-8679-a56a713476bc.png)

This is with a log from PX4 ~V1.10. Right now it's not really easy to reproduce this as there's an issue on PX4 with logging and `actuator_outputs.02`. Issue: https://github.com/PX4/PX4-Autopilot/issues/16414

Still to be done, The way that the plot titles are done is not right for these edge cases. If there's only UAVCAN the main outputs will go on AUX I believe, But this could be done in a separate PR.

Signed-off-by: Ricardo Marques <marques.ricardo17@gmail.com>