### PR TITLE
Upgrade Bokeh to Latest (2.4.3)

### DIFF
--- a/app/plot_app/theme.yaml
+++ b/app/plot_app/theme.yaml
@@ -1,8 +1,8 @@
 attrs:
 
   Axis:
-    minor_tick_in: null
-    major_tick_in: null
+    minor_tick_in: 0
+    major_tick_in: 0
     major_label_text_font_style: 'normal'
 
     axis_line_color: '#AAAAAA'

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==2.1.1
+bokeh
 jinja2
 jupyter
 pyfftw


### PR DESCRIPTION
These changes upgrade flight review to the latest version of bokeh (currently 2.4.3).

This also fixes compatibility between Jinja2 and Bokeh: Issue #234 