### PR TITLE
Tailsitter attitude correction

### DIFF
--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -17,7 +17,6 @@ from plotted_tables import (
     get_hardfault_html, get_corrupt_log_html
     )
 
-#from scipy.spatial.transform import Rotation as Rot
 from vtol_tailsitter import *
 
 #pylint: disable=cell-var-from-loop, undefined-loop-variable,

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -256,8 +256,6 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # Roll/Pitch/Yaw angle & angular rate
     for index, axis in enumerate(['roll', 'pitch', 'yaw']):
-        print(axis)
-        print(index)
         # angle
         axis_name = axis.capitalize()
         data_plot = DataPlot(data, plot_config, 'vehicle_attitude',

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -74,15 +74,13 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
     # VTOL state changes & vehicle type
     vtol_states = None
     is_vtol = False
+    is_vtol_tailsitter = False
     try:
         cur_dataset = ulog.get_dataset('vehicle_status')
         if np.amax(cur_dataset.data['is_vtol']) == 1:
             is_vtol = True
             # check if is tailsitter
             is_vtol_tailsitter = np.amax(cur_dataset.data['is_vtol_tailsitter']) ==1
-                is_vtol_tailsitter = True
-            else:
-                is_vtol_tailsitter = False
             # find mode after transitions (states: 1=transition, 2=FW, 3=MC)
             if 'vehicle_type' in cur_dataset.data:
                 vehicle_type_field = 'vehicle_type'
@@ -195,7 +193,6 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # VTOL tailistter orientation conversion, if relevant
     if is_vtol_tailsitter:
-        print(vtol_states)
         for d in data:
             if d.name == 'vehicle_attitude':
                 q0 = d.data["q[0]"]
@@ -243,7 +240,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
         for i in vtol_states:
             # states: 1=transition, 2=FW, 3=MC
             # if in FW mode then used FW conversions 
-            if is_FW == True:
+            if is_FW:
                 FW_end = i[0]
                 roll[np.logical_and(qt>FW_start,qt<FW_end)] = roll_fw[np.logical_and(qt>FW_start,qt<FW_end)]
                 pitch[np.logical_and(qt>FW_start,qt<FW_end)] = pitch_fw[np.logical_and(qt>FW_start,qt<FW_end)]

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -79,7 +79,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
         if np.amax(cur_dataset.data['is_vtol']) == 1:
             is_vtol = True
             # check if is tailsitter
-            if np.amax(cur_dataset.data['is_vtol_tailsitter']) ==1:
+            is_vtol_tailsitter = np.amax(cur_dataset.data['is_vtol_tailsitter']) ==1
                 is_vtol_tailsitter = True
             else:
                 is_vtol_tailsitter = False

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -193,7 +193,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # VTOL tailistter orientation conversion, if relevant
     if is_vtol_tailsitter:
-        [RPY, rates] = correct_tailsitter_attitude_and_rates(data, vtol_states) 
+        [RPY, rates] = correct_tailsitter_attitude_and_rates(ulog,data, vtol_states)
 
     # Roll/Pitch/Yaw angle & angular rate
     for index, axis in enumerate(['roll', 'pitch', 'yaw']):
@@ -205,14 +205,14 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              x_range=x_range)
         if is_vtol_tailsitter:
             try:
-                data_plot.add_graph([lambda data: (axis+'_q', np.rad2deg(RPY[axis]))],colors3[0:1],[axis_name+' Estimated'],mark_nan=True)
+                data_plot.add_graph([lambda data: (axis+'_q', np.rad2deg(RPY[axis]))],
+                                colors3[0:1],[axis_name+' Estimated'],mark_nan=True)
             except:
                 pass
         else:
             data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
                             colors3[0:1], [axis_name+' Estimated'], mark_nan=True)
-  
-        
+
         data_plot.change_dataset('vehicle_attitude_setpoint')
         data_plot.add_graph([lambda data: (axis+'_d', np.rad2deg(data[axis+'_d']))],
                             colors3[1:2], [axis_name+' Setpoint'],
@@ -236,7 +236,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              x_range=x_range)
         if is_vtol_tailsitter:
             try:
-                data_plot.add_graph([lambda data: (axis+'_q',np.rad2deg(rates[axis]))],colors3[0:1],[axis_name+' Rate Estimated'],mark_nan=True)
+                data_plot.add_graph([lambda data: (axis+'_q',np.rad2deg(rates[axis]))],
+                                colors3[0:1],[axis_name+' Rate Estimated'],mark_nan=True)
             except:
                 pass
         else:

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -275,7 +275,10 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         if is_vtol_tailsitter:
-            data_plot.add_graph([lambda data: (axis+'_q', np.rad2deg(RPY[axis]))],colors3[0:1],[axis_name+' Estimated'],mark_nan=True)
+            try:
+                data_plot.add_graph([lambda data: (axis+'_q', np.rad2deg(RPY[axis]))],colors3[0:1],[axis_name+' Estimated'],mark_nan=True)
+            except:
+                pass
         else:
             data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
                             colors3[0:1], [axis_name+' Estimated'], mark_nan=True)
@@ -302,8 +305,11 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              y_axis_label='[deg/s]', title=axis_name+' Angular Rate',
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
-        if is_vtol_tailsitter: 
-            data_plot.add_graph([lambda data: (axis+'_q',np.rad2deg(rates[axis]))],colors3[0:1],[axis_name+' Rate Estimated'],mark_nan=True)
+        if is_vtol_tailsitter:
+            try:
+                data_plot.add_graph([lambda data: (axis+'_q',np.rad2deg(rates[axis]))],colors3[0:1],[axis_name+' Rate Estimated'],mark_nan=True)
+            except:
+                pass
         else:
             data_plot.add_graph([lambda data: (axis+'speed',
                                                np.rad2deg(data[rate_field_names[index]]))],

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -17,7 +17,8 @@ from plotted_tables import (
     get_hardfault_html, get_corrupt_log_html
     )
 
-from scipy.spatial.transform import Rotation as Rot
+#from scipy.spatial.transform import Rotation as Rot
+from vtol_tailsitter import *
 
 #pylint: disable=cell-var-from-loop, undefined-loop-variable,
 #pylint: disable=consider-using-enumerate,too-many-statements
@@ -193,78 +194,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # VTOL tailistter orientation conversion, if relevant
     if is_vtol_tailsitter:
-        for d in data:
-            if d.name == 'vehicle_attitude':
-                q0 = d.data["q[0]"]
-                q1 = d.data["q[1]"]
-                q2 = d.data["q[2]"]
-                q3 = d.data["q[3]"]
-                qt = d.data["timestamp"]
-            if d.name == 'vehicle_angular_velocity':
-                w_r = d.data["xyz[0]"]
-                w_p = d.data["xyz[1]"]
-                w_y = d.data["xyz[2]"]
-                w_t = d.data["timestamp"]
-    
-        rotations = Rot.from_quat(np.transpose(np.asarray([q0,q1,q2,q3])))
-        RPY = rotations.as_euler('xyz',degrees=True)
-        # rotate by -90 degrees pitch in quaternion form to avoid singularity
-        FW_rotation = Rot.from_euler('y',-90,degrees=True)
-        RPY_FW = (FW_rotation*rotations).as_euler('xyz',degrees=True)
-
-        # convert out into separate variables
-        roll = np.deg2rad(RPY[:,2])
-        pitch = np.deg2rad(-1*RPY[:,1])
-        yaw = -180-RPY[:,0]
-        yaw[yaw>180]=yaw[yaw>180]-360
-        yaw[yaw<-180]=yaw[yaw<-180]+360
-        yaw = np.deg2rad(yaw)
-
-        roll_fw = np.deg2rad(RPY_FW[:,2])
-        pitch_fw = np.deg2rad(-1*RPY_FW[:,1])
-        yaw_fw = -180-RPY_FW[:,0]
-        yaw_fw[yaw_fw>180]=yaw_fw[yaw_fw>180]-360
-        yaw_fw[yaw_fw<-180]=yaw_fw[yaw_fw<-180]+360
-        yaw_fw = np.deg2rad(yaw_fw)
-        
-        # fw rates (roll and yaw swap, roll is negative axis)
-        w_r_fw = w_y*-1
-        w_p_fw = w_p
-        w_y_fw = w_r
-
-        # temporary variables for storing VTOL states
-        is_FW = False
-        FW_start = np.nan
-        FW_end = np.nan
-
-        for i in vtol_states:
-            # states: 1=transition, 2=FW, 3=MC
-            # if in FW mode then used FW conversions 
-            if is_FW:
-                FW_end = i[0]
-                roll[np.logical_and(qt>FW_start,qt<FW_end)] = roll_fw[np.logical_and(qt>FW_start,qt<FW_end)]
-                pitch[np.logical_and(qt>FW_start,qt<FW_end)] = pitch_fw[np.logical_and(qt>FW_start,qt<FW_end)]
-                yaw[np.logical_and(qt>FW_start,qt<FW_end)] = yaw_fw[np.logical_and(qt>FW_start,qt<FW_end)]
-                w_r[np.logical_and(w_t>FW_start,w_t<FW_end)] = w_r_fw[np.logical_and(w_t>FW_start,w_t<FW_end)]
-
-                is_FW = False
-            if i[1] == 2:
-                FW_start = i[0]
-                is_FW = True
-
-        # if flight ended as FW, convert the final data segment to FW
-        if is_FW == True:
-            roll[qt>FW_start] = roll_fw[qt>FW_start]
-            pitch[qt>FW_start] = pitch_fw[qt>FW_start]
-            yaw[qt>FW_start] = yaw_fw[qt>FW_start]
-            w_r[qt>FW_start] = w_r_fw[qt>FW_start]
-            w_p[qt>FW_start] = w_p_fw[qt>FW_start]
-            w_y[qt>FW_start] = w_y_fw[qt>FW_start]
-        
-        RPY = {'roll': roll, 'pitch': pitch, 'yaw': yaw}
-        rates = {'roll': w_r, 'pitch': w_p, 'yaw': w_y}   
-
-    
+        [RPY, rates] = correct_tailsitter_attitude_and_rates(data, vtol_states) 
 
     # Roll/Pitch/Yaw angle & angular rate
     for index, axis in enumerate(['roll', 'pitch', 'yaw']):

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -80,7 +80,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
         if np.amax(cur_dataset.data['is_vtol']) == 1:
             is_vtol = True
             # check if is tailsitter
-            is_vtol_tailsitter = np.amax(cur_dataset.data['is_vtol_tailsitter']) ==1
+            is_vtol_tailsitter = np.amax(cur_dataset.data['is_vtol_tailsitter']) == 1
             # find mode after transitions (states: 1=transition, 2=FW, 3=MC)
             if 'vehicle_type' in cur_dataset.data:
                 vehicle_type_field = 'vehicle_type'
@@ -193,7 +193,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # VTOL tailistter orientation conversion, if relevant
     if is_vtol_tailsitter:
-        [RPY, rates] = correct_tailsitter_attitude_and_rates(ulog,data, vtol_states)
+        [tailsitter_attitude, tailsitter_rates] = tailsitter_orientation(ulog, vtol_states)
 
     # Roll/Pitch/Yaw angle & angular rate
     for index, axis in enumerate(['roll', 'pitch', 'yaw']):
@@ -204,14 +204,13 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         if is_vtol_tailsitter:
-            try:
-                data_plot.add_graph([lambda data: (axis+'_q', np.rad2deg(RPY[axis]))],
-                                colors3[0:1],[axis_name+' Estimated'],mark_nan=True)
-            except:
-                pass
+            if tailsitter_attitude[axis] is not None:
+                data_plot.add_graph([lambda data: (axis+'_q',
+                                                   np.rad2deg(tailsitter_attitude[axis]))],
+                                    colors3[0:1], [axis_name+' Estimated'], mark_nan=True)
         else:
             data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
-                            colors3[0:1], [axis_name+' Estimated'], mark_nan=True)
+                                colors3[0:1], [axis_name+' Estimated'], mark_nan=True)
 
         data_plot.change_dataset('vehicle_attitude_setpoint')
         data_plot.add_graph([lambda data: (axis+'_d', np.rad2deg(data[axis+'_d']))],
@@ -235,11 +234,10 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         if is_vtol_tailsitter:
-            try:
-                data_plot.add_graph([lambda data: (axis+'_q',np.rad2deg(rates[axis]))],
-                                colors3[0:1],[axis_name+' Rate Estimated'],mark_nan=True)
-            except:
-                pass
+            if tailsitter_rates[axis] is not None:
+                data_plot.add_graph([lambda data: (axis+'_q',
+                                                   np.rad2deg(tailsitter_rates[axis]))],
+                                    colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
         else:
             data_plot.add_graph([lambda data: (axis+'speed',
                                                np.rad2deg(data[rate_field_names[index]]))],

--- a/app/plot_app/vtol_tailsitter.py
+++ b/app/plot_app/vtol_tailsitter.py
@@ -1,0 +1,81 @@
+# VTOL tailsitter attitude and rate correction code
+# tailsitter uses 90 degree rotation in pitch which is hardcoded in rather than consistently reported in estimated and setpoint
+# use setpoint values as ground truth here and correct estimated by 90 degrees
+
+from scipy.spatial.transform import Rotation as Rot
+import numpy as np
+
+def correct_tailsitter_attitude_and_rates(data,vtol_states):
+
+    for d in data:
+        if d.name == 'vehicle_attitude':
+            q0 = d.data["q[0]"]
+            q1 = d.data["q[1]"]
+            q2 = d.data["q[2]"]
+            q3 = d.data["q[3]"]
+            qt = d.data["timestamp"]
+        if d.name == 'vehicle_angular_velocity':
+            w_r = d.data["xyz[0]"]
+            w_p = d.data["xyz[1]"]
+            w_y = d.data["xyz[2]"]
+            w_t = d.data["timestamp"]
+
+    rotations = Rot.from_quat(np.transpose(np.asarray([q0,q1,q2,q3])))
+    RPY = rotations.as_euler('xyz',degrees=True)
+    # rotate by -90 degrees pitch in quaternion form to avoid singularity
+    FW_rotation = Rot.from_euler('y',-90,degrees=True)
+    RPY_FW = (FW_rotation*rotations).as_euler('xyz',degrees=True)
+
+    # convert out into separate variables
+    roll = np.deg2rad(RPY[:,2])
+    pitch = np.deg2rad(-1*RPY[:,1])
+    yaw = -180-RPY[:,0]
+    yaw[yaw>180]=yaw[yaw>180]-360
+    yaw[yaw<-180]=yaw[yaw<-180]+360
+    yaw = np.deg2rad(yaw)
+
+    roll_fw = np.deg2rad(RPY_FW[:,2])
+    pitch_fw = np.deg2rad(-1*RPY_FW[:,1])
+    yaw_fw = -180-RPY_FW[:,0]
+    yaw_fw[yaw_fw>180]=yaw_fw[yaw_fw>180]-360
+    yaw_fw[yaw_fw<-180]=yaw_fw[yaw_fw<-180]+360
+    yaw_fw = np.deg2rad(yaw_fw)
+
+    # fw rates (roll and yaw swap, roll is negative axis)
+    w_r_fw = w_y*-1
+    w_p_fw = w_p
+    w_y_fw = w_r
+
+    # temporary variables for storing VTOL states
+    is_FW = False
+    FW_start = np.nan
+    FW_end = np.nan
+
+    for i in vtol_states:
+    # states: 1=transition, 2=FW, 3=MC
+    # if in FW mode then used FW conversions 
+        if is_FW:
+            FW_end = i[0]
+            roll[np.logical_and(qt>FW_start,qt<FW_end)] = roll_fw[np.logical_and(qt>FW_start,qt<FW_end)]
+            pitch[np.logical_and(qt>FW_start,qt<FW_end)] = pitch_fw[np.logical_and(qt>FW_start,qt<FW_end)]
+            yaw[np.logical_and(qt>FW_start,qt<FW_end)] = yaw_fw[np.logical_and(qt>FW_start,qt<FW_end)]
+            w_r[np.logical_and(w_t>FW_start,w_t<FW_end)] = w_r_fw[np.logical_and(w_t>FW_start,w_t<FW_end)]
+
+            is_FW = False
+        if i[1] == 2:
+            FW_start = i[0]
+            is_FW = True
+
+    # if flight ended as FW, convert the final data segment to FW
+    if is_FW:
+        roll[qt>FW_start] = roll_fw[qt>FW_start]
+        pitch[qt>FW_start] = pitch_fw[qt>FW_start]
+        yaw[qt>FW_start] = yaw_fw[qt>FW_start]
+        w_r[qt>FW_start] = w_r_fw[qt>FW_start]
+        w_p[qt>FW_start] = w_p_fw[qt>FW_start]
+        w_y[qt>FW_start] = w_y_fw[qt>FW_start]
+
+    RPY = {'roll': roll, 'pitch': pitch, 'yaw': yaw}
+    rates = {'roll': w_r, 'pitch': w_p, 'yaw': w_y} 
+
+    return [RPY, rates]

--- a/app/plot_app/vtol_tailsitter.py
+++ b/app/plot_app/vtol_tailsitter.py
@@ -1,81 +1,116 @@
-# VTOL tailsitter attitude and rate correction code
-# tailsitter uses 90 degree rotation in pitch which is hardcoded in rather than consistently reported in estimated and setpoint
-# use setpoint values as ground truth here and correct estimated by 90 degrees
+""" VTOL tailsitter attitude and rate correction code """
 
 from scipy.spatial.transform import Rotation as Rot
 import numpy as np
 
-def correct_tailsitter_attitude_and_rates(data,vtol_states):
+def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
+    """
+    corrections for VTOL tailsitter attitude and rates
+    tailsitter uses 90 degree rotation in pitch which is hardcoded in 
+    rather than consistently reported in estimated and setpoint
+    use setpoint values as ground truth here and correct estimated by 90 degrees
+    rates also need yaw and roll swapped with a -1 on roll axis    
+    """
+    # correct attitudes for VTOL tailsitter in FW mode
+    try:
+        cur_dataset = ulog.get_dataset('vehicle_attitude')
+        quat_0 = cur_dataset.data['q[0]']
+        quat_1 = cur_dataset.data['q[1]']
+        quat_2 = cur_dataset.data['q[2]']
+        quat_3 = cur_dataset.data['q[3]']
+        quat_t = cur_dataset.data['timestamp']
+        
+        rotations = Rot.from_quat(np.transpose(np.asarray([quat_0,quat_1,quat_2,quat_3])))
+        rpy = rotations.as_euler('xyz',degrees=True)
+        # rotate by -90 degrees pitch in quaternion form to avoid singularity
+        fw_rotation = Rot.from_euler('y',-90,degrees=True)
+        rpy_fw = (fw_rotation*rotations).as_euler('xyz',degrees=True)
 
-    for d in data:
-        if d.name == 'vehicle_attitude':
-            q0 = d.data["q[0]"]
-            q1 = d.data["q[1]"]
-            q2 = d.data["q[2]"]
-            q3 = d.data["q[3]"]
-            qt = d.data["timestamp"]
-        if d.name == 'vehicle_angular_velocity':
-            w_r = d.data["xyz[0]"]
-            w_p = d.data["xyz[1]"]
-            w_y = d.data["xyz[2]"]
-            w_t = d.data["timestamp"]
+        # convert out into separate variables
+        roll = np.deg2rad(rpy[:,2])
+        pitch = np.deg2rad(-1*rpy[:,1])
+        yaw = -180-rpy[:,0]
+        yaw[yaw>180]=yaw[yaw>180]-360
+        yaw[yaw<-180]=yaw[yaw<-180]+360
+        yaw = np.deg2rad(yaw)
+    
+        roll_fw = np.deg2rad(rpy_fw[:,2])
+        pitch_fw = np.deg2rad(-1*rpy_fw[:,1])
+        yaw_fw = -180-rpy_fw[:,0]
+        yaw_fw[yaw_fw>180]=yaw_fw[yaw_fw>180]-360
+        yaw_fw[yaw_fw<-180]=yaw_fw[yaw_fw<-180]+360
+        yaw_fw = np.deg2rad(yaw_fw)
+        
+        # temporary variables for storing VTOL states
+        is_vtol_fw = False
+        fw_start = np.nan
+        fw_end = np.nan
 
-    rotations = Rot.from_quat(np.transpose(np.asarray([q0,q1,q2,q3])))
-    RPY = rotations.as_euler('xyz',degrees=True)
-    # rotate by -90 degrees pitch in quaternion form to avoid singularity
-    FW_rotation = Rot.from_euler('y',-90,degrees=True)
-    RPY_FW = (FW_rotation*rotations).as_euler('xyz',degrees=True)
+        for i in vtol_states:
+        # states: 1=transition, 2=FW, 3=MC
+        # if in FW mode then used FW conversions
+            if is_vtol_fw:
+                fw_end = i[0]
+                roll[np.logical_and(quat_t>fw_start,quat_t<fw_end)] = \
+                                roll_fw[np.logical_and(quat_t>fw_start,quat_t<fw_end)]
+                pitch[np.logical_and(quat_t>fw_start,quat_t<fw_end)] = \
+                                pitch_fw[np.logical_and(quat_t>fw_start,quat_t<fw_end)]
+                yaw[np.logical_and(quat_t>fw_start,quat_t<fw_end)] = \
+                                yaw_fw[np.logical_and(quat_t>fw_start,quat_t<fw_end)]
+                is_vtol_fw = False
+            if i[1] == 2:
+                fw_start = i[0]
+                is_vtol_fw = True
 
-    # convert out into separate variables
-    roll = np.deg2rad(RPY[:,2])
-    pitch = np.deg2rad(-1*RPY[:,1])
-    yaw = -180-RPY[:,0]
-    yaw[yaw>180]=yaw[yaw>180]-360
-    yaw[yaw<-180]=yaw[yaw<-180]+360
-    yaw = np.deg2rad(yaw)
+        # if flight ended as FW, convert the final data segment to FW
+        if is_vtol_fw:
+            roll[quat_t>fw_start] = roll_fw[quat_t>fw_start]
+            pitch[quat_t>fw_start] = pitch_fw[quat_t>fw_start]
+            yaw[quat_t>fw_start] = yaw_fw[quat_t>fw_start]
 
-    roll_fw = np.deg2rad(RPY_FW[:,2])
-    pitch_fw = np.deg2rad(-1*RPY_FW[:,1])
-    yaw_fw = -180-RPY_FW[:,0]
-    yaw_fw[yaw_fw>180]=yaw_fw[yaw_fw>180]-360
-    yaw_fw[yaw_fw<-180]=yaw_fw[yaw_fw<-180]+360
-    yaw_fw = np.deg2rad(yaw_fw)
+        vtol_attitude = {'roll': roll, 'pitch': pitch, 'yaw': yaw}
 
-    # fw rates (roll and yaw swap, roll is negative axis)
-    w_r_fw = w_y*-1
-    w_p_fw = w_p
-    w_y_fw = w_r
+    except (KeyError, IndexError) as error:
+        vtol_attitude = {'roll': None, 'pitch': None, 'yaw': None}
 
-    # temporary variables for storing VTOL states
-    is_FW = False
-    FW_start = np.nan
-    FW_end = np.nan
+    # correct angular rates for VTOL tailsitter in FW mode
+    try: 
+        cur_dataset = ulog.get_dataset('vehicle_angular_velocity')
+        w_r = cur_dataset.data['xyz[0]']
+        w_p = cur_dataset.data['xyz[1]']
+        w_y = cur_dataset.data['xyz[2]']
+        w_t = cur_dataset.data['timestamp']
+        
+        # fw rates (roll and yaw swap, roll is negative axis)
+        w_r_fw = w_y*-1
+        w_y_fw = w_r*1 # *1 to get python to copy not reference
+        # temporary variables for storing VTOL states
+        is_vtol_fw = False
+        fw_start = np.nan
+        fw_end = np.nan
 
-    for i in vtol_states:
-    # states: 1=transition, 2=FW, 3=MC
-    # if in FW mode then used FW conversions 
-        if is_FW:
-            FW_end = i[0]
-            roll[np.logical_and(qt>FW_start,qt<FW_end)] = roll_fw[np.logical_and(qt>FW_start,qt<FW_end)]
-            pitch[np.logical_and(qt>FW_start,qt<FW_end)] = pitch_fw[np.logical_and(qt>FW_start,qt<FW_end)]
-            yaw[np.logical_and(qt>FW_start,qt<FW_end)] = yaw_fw[np.logical_and(qt>FW_start,qt<FW_end)]
-            w_r[np.logical_and(w_t>FW_start,w_t<FW_end)] = w_r_fw[np.logical_and(w_t>FW_start,w_t<FW_end)]
+        for i in vtol_states:
+        # states: 1=transition, 2=FW, 3=MC
+        # if in FW mode then used FW conversions
+            if is_vtol_fw:
+                fw_end = i[0]
+                w_r[np.logical_and(w_t>fw_start,w_t<fw_end)] = \
+                                w_r_fw[np.logical_and(w_t>fw_start,w_t<fw_end)]
+                w_y[np.logical_and(w_t>fw_start,w_t<fw_end)] = \
+                                w_y_fw[np.logical_and(w_t>fw_start,w_t<fw_end)]
+                is_vtol_fw = False
+            if i[1] == 2:
+                fw_start = i[0]
+                is_vtol_fw = True
 
-            is_FW = False
-        if i[1] == 2:
-            FW_start = i[0]
-            is_FW = True
-
-    # if flight ended as FW, convert the final data segment to FW
-    if is_FW:
-        roll[qt>FW_start] = roll_fw[qt>FW_start]
-        pitch[qt>FW_start] = pitch_fw[qt>FW_start]
-        yaw[qt>FW_start] = yaw_fw[qt>FW_start]
-        w_r[qt>FW_start] = w_r_fw[qt>FW_start]
-        w_p[qt>FW_start] = w_p_fw[qt>FW_start]
-        w_y[qt>FW_start] = w_y_fw[qt>FW_start]
-
-    RPY = {'roll': roll, 'pitch': pitch, 'yaw': yaw}
-    rates = {'roll': w_r, 'pitch': w_p, 'yaw': w_y} 
-
-    return [RPY, rates]
+        # if flight ended as FW, convert the final data segment to FW
+        if is_vtol_fw:
+            w_r[quat_t>fw_start] = w_r_fw[quat_t>fw_start]
+            w_y[quat_t>fw_start] = w_y_fw[quat_t>fw_start]
+            
+        vtol_rates = {'roll': w_r, 'pitch': w_p, 'yaw': w_y}
+        
+    except (KeyError, IndexError) as error:
+        vtol_rates = {'roll': None, 'pitch': None, 'yaw': None}
+    
+    return [vtol_attitude, vtol_rates]

--- a/app/plot_app/vtol_tailsitter.py
+++ b/app/plot_app/vtol_tailsitter.py
@@ -3,13 +3,13 @@
 from scipy.spatial.transform import Rotation as Rot
 import numpy as np
 
-def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
+def tailsitter_orientation(ulog, vtol_states):
     """
     corrections for VTOL tailsitter attitude and rates
-    tailsitter uses 90 degree rotation in pitch which is hardcoded in 
+    tailsitter uses 90 degree rotation in pitch which is hardcoded in
     rather than consistently reported in estimated and setpoint
     use setpoint values as ground truth here and correct estimated by 90 degrees
-    rates also need yaw and roll swapped with a -1 on roll axis    
+    rates also need yaw and roll swapped with a -1 on roll axis
     """
     # correct attitudes for VTOL tailsitter in FW mode
     try:
@@ -19,28 +19,28 @@ def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
         quat_2 = cur_dataset.data['q[2]']
         quat_3 = cur_dataset.data['q[3]']
         quat_t = cur_dataset.data['timestamp']
-        
-        rotations = Rot.from_quat(np.transpose(np.asarray([quat_0,quat_1,quat_2,quat_3])))
-        rpy = rotations.as_euler('xyz',degrees=True)
+
+        rotations = Rot.from_quat(np.transpose(np.asarray([quat_0, quat_1, quat_2, quat_3])))
+        rpy = rotations.as_euler('xyz', degrees=True)
         # rotate by -90 degrees pitch in quaternion form to avoid singularity
-        fw_rotation = Rot.from_euler('y',-90,degrees=True)
-        rpy_fw = (fw_rotation*rotations).as_euler('xyz',degrees=True)
+        fw_rotation = Rot.from_euler('y', -90, degrees=True)
+        rpy_fw = (fw_rotation*rotations).as_euler('xyz', degrees=True)
 
         # convert out into separate variables
-        roll = np.deg2rad(rpy[:,2])
-        pitch = np.deg2rad(-1*rpy[:,1])
-        yaw = -180-rpy[:,0]
-        yaw[yaw>180]=yaw[yaw>180]-360
-        yaw[yaw<-180]=yaw[yaw<-180]+360
+        roll = np.deg2rad(rpy[:, 2])
+        pitch = np.deg2rad(-1*rpy[:, 1])
+        yaw = -180-rpy[:, 0]
+        yaw[yaw > 180] = yaw[yaw > 180]-360
+        yaw[yaw < -180] = yaw[yaw < -180]+360
         yaw = np.deg2rad(yaw)
-    
-        roll_fw = np.deg2rad(rpy_fw[:,2])
-        pitch_fw = np.deg2rad(-1*rpy_fw[:,1])
-        yaw_fw = -180-rpy_fw[:,0]
-        yaw_fw[yaw_fw>180]=yaw_fw[yaw_fw>180]-360
-        yaw_fw[yaw_fw<-180]=yaw_fw[yaw_fw<-180]+360
+
+        roll_fw = np.deg2rad(rpy_fw[:, 2])
+        pitch_fw = np.deg2rad(-1*rpy_fw[:, 1])
+        yaw_fw = -180-rpy_fw[:, 0]
+        yaw_fw[yaw_fw > 180] = yaw_fw[yaw_fw > 180]-360
+        yaw_fw[yaw_fw < -180] = yaw_fw[yaw_fw < -180]+360
         yaw_fw = np.deg2rad(yaw_fw)
-        
+
         # temporary variables for storing VTOL states
         is_vtol_fw = False
         fw_start = np.nan
@@ -51,12 +51,12 @@ def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
         # if in FW mode then used FW conversions
             if is_vtol_fw:
                 fw_end = i[0]
-                roll[np.logical_and(quat_t>fw_start,quat_t<fw_end)] = \
-                                roll_fw[np.logical_and(quat_t>fw_start,quat_t<fw_end)]
-                pitch[np.logical_and(quat_t>fw_start,quat_t<fw_end)] = \
-                                pitch_fw[np.logical_and(quat_t>fw_start,quat_t<fw_end)]
-                yaw[np.logical_and(quat_t>fw_start,quat_t<fw_end)] = \
-                                yaw_fw[np.logical_and(quat_t>fw_start,quat_t<fw_end)]
+                roll[np.logical_and(quat_t > fw_start, quat_t < fw_end)] = \
+                                roll_fw[np.logical_and(quat_t > fw_start, quat_t < fw_end)]
+                pitch[np.logical_and(quat_t > fw_start, quat_t < fw_end)] = \
+                                pitch_fw[np.logical_and(quat_t > fw_start, quat_t < fw_end)]
+                yaw[np.logical_and(quat_t > fw_start, quat_t < fw_end)] = \
+                                yaw_fw[np.logical_and(quat_t > fw_start, quat_t < fw_end)]
                 is_vtol_fw = False
             if i[1] == 2:
                 fw_start = i[0]
@@ -64,9 +64,9 @@ def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
 
         # if flight ended as FW, convert the final data segment to FW
         if is_vtol_fw:
-            roll[quat_t>fw_start] = roll_fw[quat_t>fw_start]
-            pitch[quat_t>fw_start] = pitch_fw[quat_t>fw_start]
-            yaw[quat_t>fw_start] = yaw_fw[quat_t>fw_start]
+            roll[quat_t > fw_start] = roll_fw[quat_t > fw_start]
+            pitch[quat_t > fw_start] = pitch_fw[quat_t > fw_start]
+            yaw[quat_t > fw_start] = yaw_fw[quat_t > fw_start]
 
         vtol_attitude = {'roll': roll, 'pitch': pitch, 'yaw': yaw}
 
@@ -74,13 +74,13 @@ def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
         vtol_attitude = {'roll': None, 'pitch': None, 'yaw': None}
 
     # correct angular rates for VTOL tailsitter in FW mode
-    try: 
+    try:
         cur_dataset = ulog.get_dataset('vehicle_angular_velocity')
         w_r = cur_dataset.data['xyz[0]']
         w_p = cur_dataset.data['xyz[1]']
         w_y = cur_dataset.data['xyz[2]']
         w_t = cur_dataset.data['timestamp']
-        
+
         # fw rates (roll and yaw swap, roll is negative axis)
         w_r_fw = w_y*-1
         w_y_fw = w_r*1 # *1 to get python to copy not reference
@@ -94,10 +94,10 @@ def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
         # if in FW mode then used FW conversions
             if is_vtol_fw:
                 fw_end = i[0]
-                w_r[np.logical_and(w_t>fw_start,w_t<fw_end)] = \
-                                w_r_fw[np.logical_and(w_t>fw_start,w_t<fw_end)]
-                w_y[np.logical_and(w_t>fw_start,w_t<fw_end)] = \
-                                w_y_fw[np.logical_and(w_t>fw_start,w_t<fw_end)]
+                w_r[np.logical_and(w_t > fw_start, w_t < fw_end)] = \
+                                w_r_fw[np.logical_and(w_t > fw_start, w_t < fw_end)]
+                w_y[np.logical_and(w_t > fw_start, w_t < fw_end)] = \
+                                w_y_fw[np.logical_and(w_t > fw_start, w_t < fw_end)]
                 is_vtol_fw = False
             if i[1] == 2:
                 fw_start = i[0]
@@ -105,12 +105,12 @@ def correct_tailsitter_attitude_and_rates(ulog,data,vtol_states):
 
         # if flight ended as FW, convert the final data segment to FW
         if is_vtol_fw:
-            w_r[quat_t>fw_start] = w_r_fw[quat_t>fw_start]
-            w_y[quat_t>fw_start] = w_y_fw[quat_t>fw_start]
-            
+            w_r[quat_t > fw_start] = w_r_fw[quat_t > fw_start]
+            w_y[quat_t > fw_start] = w_y_fw[quat_t > fw_start]
+
         vtol_rates = {'roll': w_r, 'pitch': w_p, 'yaw': w_y}
-        
+
     except (KeyError, IndexError) as error:
         vtol_rates = {'roll': None, 'pitch': None, 'yaw': None}
-    
+
     return [vtol_attitude, vtol_rates]


### PR DESCRIPTION
Hi, 
I have added some logic to do orientation conversion on attitude for tailsitters in fixed wing mode. Before this logic, tailsitters would appear very unable to track attitude trajectories in fixed wing mode. Now flight review can correctly display the tailsitter attitudes. See attached images for before and after.
![newpitch](https://user-images.githubusercontent.com/90471633/179121636-75e1cda2-74cd-4c44-891c-c6259c3b8c74.png)
![newroll](https://user-images.githubusercontent.com/90471633/179121643-44239195-12f1-4f4c-8989-2a1b85e21a75.png)
![oldpitch](https://user-images.githubusercontent.com/90471633/179121647-f3b18e0a-b16c-4841-ad06-04428fef1d23.png)
![oldroll](https://user-images.githubusercontent.com/90471633/179121652-ecc44863-afff-4645-8f07-1fddafba11ab.png)
 