### PR TITLE
Accept any scipy version over 1.8.1

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,6 +5,6 @@ pyfftw
 pylint
 pyulog>=0.9
 requests
-scipy==1.8.1
+scipy>=1.8.1
 simplekml
 smopy


### PR DESCRIPTION
## Description
I noticed that when executing `pip install -r requirements.txt`, my Scipy 1.9.3 package got downgraded, due to hard constraint in the requirements file. This doesn't seem necessary since Scipy isn't such a crucial package in general as mentioned here: https://github.com/PX4/flight_review/issues/233#issuecomment-1089857342

## Solution
Remove hard constraint on SciPy version, and accept install any version over 1.8.1 (and don't downgrade system package if already installed and is version higher than 1.8.1)