### PR TITLE
README: Make database setup more visible / mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install -r requirements.txt
 
 ### Setup
 
-Initialize the Database like following:
+Initialize the Database as following:
 
 ```bash
 ./app/setup_db.py

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ pip install -r requirements.txt
 Initialize the Database like following:
 
 ```bash
-cd app
-./setup_db.py
+./app/setup_db.py
 ```
 
 **Note:** `setup_db.py` can also be used to upgrade the database tables, for instance when new entries are added (it automatically detects that).

--- a/README.md
+++ b/README.md
@@ -58,15 +58,22 @@ pip install -r requirements.txt
 
 ### Setup
 
+Initialize the Database like following:
+
+```bash
+cd app
+./setup_db.py
+```
+
+**Note:** `setup_db.py` can also be used to upgrade the database tables, for instance when new entries are added (it automatically detects that).
+
+#### Settings
+
 - By default the app will load `config_default.ini` configuration file
 - You can override any setting from `config_default.ini` with a user config file
   `config_user.ini` (untracked)
 - Any setting on `config_user.ini` has priority over
   `config_default.ini`
-- Run `setup_db.py` to initialize the database.
-
-**Note:** `setup_db.py` can also be used to upgrade the database tables, for
-  instance when new entries are added (it automatically detects that).
 
 ## Usage
 


### PR DESCRIPTION
## Description
When I first tried to execute the web app, I noticed the log upload wasn't working, since in the README, it wasn't so obvious that it was a necessary step, as it was occluded by the optional user settings description.

## Solution
Move the Database setup step upwards and make it necessary (hard to miss)