### PR TITLE
Update vibration metric color thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ git clone --recursive https://github.com/PX4/flight_review.git
 cd flight_review/app
 pip install -r requirements.txt
 # Note: preferably use a virtualenv
+
+# Note: if you get an error about "ModuleNotFoundError: No module named 'libevents_parse'" update submodules
+git submodule update --init --recursive
 ```
 
 ### Setup

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -643,7 +643,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                          x_range=x_range, y_start=0)
     data_plot.add_graph(['accel_vibration_metric'], colors3[2:3], ['Accel Vibration Level [m/s^2]'])
     data_plot.add_horizontal_background_boxes(
-        ['green', 'orange', 'red'], [0.02, 0.04])
+        ['green', 'orange', 'red'], [4.0, 8.0])
 
     if data_plot.finalize() is not None: plots.append(data_plot)
 


### PR DESCRIPTION
The current vibration color thresholds are a couple of orders of magnitudes off from what the expected values are in PX4 now. 

I set them into the expected range but guessed at the specific values. We will need to determine the actual green, yellow, and red ranges.

The land detector uses these values to detect the last movement.
```
static constexpr float GYRO_VIBE_METRIC_MAX = 0.02f; // gyro_vibration_metric * dt * 4.0e4f > is_moving_scaler)
static constexpr float ACCEL_VIBE_METRIC_MAX = 1.2f; // accel_vibration_metric * dt * 2.1e2f > is_moving_scaler

if ((imu_status.gyro_vibration_metric > GYRO_VIBE_METRIC_MAX)
		  || (imu_status.accel_vibration_metric > ACCEL_VIBE_METRIC_MAX)) {

	_time_last_move_detect_us = imu_status.timestamp;
}
```

![image](https://user-images.githubusercontent.com/2019539/212562506-c4cf207c-9166-4c1a-a4fe-90433c7b72ee.png)
