### PR TITLE
Plot up to 4 imu vibration metrics. Update color thresholds

### DIFF
--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -640,10 +640,33 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
     data_plot = DataPlot(data, plot_config, 'vehicle_imu_status',
                          title='Vibration Metrics',
                          plot_height='small', changed_params=changed_params,
-                         x_range=x_range, y_start=0)
-    data_plot.add_graph(['accel_vibration_metric'], colors3[2:3], ['Accel Vibration Level [m/s^2]'])
+                         x_range=x_range, y_start=0, topic_instance=0)
+    data_plot.add_graph(['accel_vibration_metric'], colors8[0:1],
+                         ['Accel 0 Vibration Level [m/s^2]'])
+
+    try:
+        data_plot.change_dataset('vehicle_imu_status', 1)
+        data_plot.add_graph(['accel_vibration_metric'], colors8[1:2],
+                             ['Accel 1 Vibration Level [m/s^2]'])
+    except:
+        pass
+
+    try:
+        data_plot.change_dataset('vehicle_imu_status', 2)
+        data_plot.add_graph(['accel_vibration_metric'], colors8[2:3],
+                             ['Accel 2 Vibration Level [m/s^2]'])
+    except:
+        pass
+
+    try:
+        data_plot.change_dataset('vehicle_imu_status', 3)
+        data_plot.add_graph(['accel_vibration_metric'], colors8[3:4],
+                             ['Accel 3 Vibration Level [rad/s]'])
+    except:
+        pass
+
     data_plot.add_horizontal_background_boxes(
-        ['green', 'orange', 'red'], [4.0, 8.0])
+        ['green', 'orange', 'red'], [4.905, 9.81])
 
     if data_plot.finalize() is not None: plots.append(data_plot)
 


### PR DESCRIPTION
Show up to 4 IMUs. Usually 2-3 internal and possibly 1 external IMU.

Change the color thresholds to be gravity and 1/2 gravity.

![image](https://user-images.githubusercontent.com/2019539/212564268-0f8f923b-215d-48f0-adee-15caba22bc45.png)

![image](https://user-images.githubusercontent.com/2019539/212564417-c89bd794-0363-4bc5-8916-c91b251e295a.png)

![image](https://user-images.githubusercontent.com/2019539/212564625-756b074f-fe49-411d-8918-8249069af796.png)

