### PR TITLE
Handle -inf in PSD plots

### DIFF
--- a/app/plot_app/plotting.py
+++ b/app/plot_app/plotting.py
@@ -855,7 +855,16 @@ class DataPlotSpec(DataPlot):
             # scale time to microseconds and add start time as offset
             time = time * 1.0e6 + self._cur_dataset.data[timestamp_key][0]
 
-            image = [10 * np.log10(sum_psd)]
+            inner_image = 10 * np.log10(sum_psd)
+            # Bokeh/JSON can't handle -inf.
+            # Replace any -inf values with the smallest finite number in the
+            # dataset. We aren't using something like INT_MIN because we
+            # don't want to mess up scaling too much.
+            if -np.inf in inner_image:
+                finite_min = np.min(np.ma.masked_invalid(inner_image))
+                inner_image[inner_image == -np.inf] = finite_min
+            image = [inner_image]
+
             title = self.title
             for legend in legends:
                 title += " " + legend


### PR DESCRIPTION
In weird instances, if the raw values being used to create PSD plots are exactly constant, the PSD will have 0's which underflow when doing a log10 scale. This causes a failure when the JSON is deserialized. We replace -inf with the smallest finite number that's already in the PSD.