### PR TITLE
Fix FIFO spectrogram plot

### DIFF
--- a/app/plot_app/plotting.py
+++ b/app/plot_app/plotting.py
@@ -83,6 +83,7 @@ def add_virtual_fifo_topic_data(ulog, topic_name):
                     xyz_new[j][sample+s] = data_point
             sample += samples[i]
         cur_dataset.data['timestamp'] = t_new
+        cur_dataset.data['timestamp_sample'] = t_new
         cur_dataset.data['x'] = xyz_new[0]
         cur_dataset.data['y'] = xyz_new[1]
         cur_dataset.data['z'] = xyz_new[2]


### PR DESCRIPTION
timestamp_sample exists in the original dataset and is used by the spectrogram plotter; it needs to be fill correctly to have the right dimension

Before:
![spectrogram_issue](https://github.com/PX4/flight_review/assets/14822839/fa6d33cd-f0e4-4331-bb8c-197e2607cdfa)

This PR:
![spectrogram_fixed](https://github.com/PX4/flight_review/assets/14822839/6c8da74b-c0c8-4905-ac4c-ecb7c6a85f5f)
