### PR TITLE
Plot all available FIFO instances 

### DIFF
--- a/app/plot_app/config.py
+++ b/app/plot_app/config.py
@@ -57,15 +57,15 @@ plot_width = 840
 plot_color_blue = '#2877a2' # or: #3539e0
 plot_color_red = '#e0212d'
 
-plot_config = dict(
-    maps_line_color = plot_color_blue,
-    plot_width = plot_width,
-    plot_height = dict(
-        normal = int(plot_width / 2.1),
-        small = int(plot_width / 2.5),
-        large = int(plot_width / 1.61803398874989484), # used for the gps map
-        ),
-    )
+plot_config = {
+    'maps_line_color': plot_color_blue,
+    'plot_width': plot_width,
+    'plot_height': {
+        'normal': int(plot_width / 2.1),
+        'small': int(plot_width / 2.5),
+        'large': int(plot_width / 1.61803398874989484), # used for the gps map
+        },
+    }
 
 colors3 = [plot_color_red, '#208900', plot_color_blue]
 colors2 = [colors3[0], colors3[1]] # for data to express: 'what it is' and 'what it should be'

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -704,57 +704,64 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
     if data_plot.finalize() is not None: plots.append(data_plot)
 
     # FIFO accel
-    if add_virtual_fifo_topic_data(ulog, 'sensor_accel_fifo'):
-        # Raw data
-        data_plot = DataPlot(data, plot_config, 'sensor_accel_fifo_virtual',
-                             y_axis_label='[m/s^2]', title='Raw Acceleration (FIFO)',
-                             plot_height='small', changed_params=changed_params,
-                             x_range=x_range)
-        data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
-        if data_plot.finalize() is not None: plots.append(data_plot)
+    for instance in range(3):
+        if add_virtual_fifo_topic_data(ulog, 'sensor_accel_fifo', instance):
+            # Raw data
+            data_plot = DataPlot(data, plot_config, 'sensor_accel_fifo_virtual',
+                                 y_axis_label='[m/s^2]',
+                                 title=f'Raw Acceleration (FIFO, IMU{instance})',
+                                 plot_height='small', changed_params=changed_params,
+                                 x_range=x_range, topic_instance=instance)
+            data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
+            if data_plot.finalize() is not None: plots.append(data_plot)
 
-        # power spectral density
-        data_plot = DataPlotSpec(data, plot_config, 'sensor_accel_fifo_virtual',
-                                 y_axis_label='[Hz]',
-                                 title='Acceleration Power Spectral Density (FIFO)',
-                                 plot_height='normal', x_range=x_range)
-        data_plot.add_graph(['x', 'y', 'z'], ['X', 'Y', 'Z'])
-        if data_plot.finalize() is not None: plots.append(data_plot)
+            # power spectral density
+            data_plot = DataPlotSpec(data, plot_config, 'sensor_accel_fifo_virtual',
+                                     y_axis_label='[Hz]',
+                                     title=(f'Acceleration Power Spectral Density'
+                                            f'(FIFO, IMU{instance})'),
+                                     plot_height='normal', x_range=x_range, topic_instance=instance)
+            data_plot.add_graph(['x', 'y', 'z'], ['X', 'Y', 'Z'])
+            if data_plot.finalize() is not None: plots.append(data_plot)
 
-        # sampling regularity
-        data_plot = DataPlot(data, plot_config, 'sensor_accel_fifo', y_range=Range1d(0, 25e3),
-                             y_axis_label='[us]',
-                             title='Sampling Regularity of Sensor Data (FIFO)', plot_height='small',
-                             changed_params=changed_params, x_range=x_range)
-        sensor_accel_fifo = ulog.get_dataset('sensor_accel_fifo').data
-        sampling_diff = np.diff(sensor_accel_fifo['timestamp'])
-        min_sampling_diff = np.amin(sampling_diff)
-        plot_dropouts(data_plot.bokeh_plot, ulog.dropouts, min_sampling_diff)
-        data_plot.add_graph([lambda data: ('timediff', np.append(sampling_diff, 0))],
-                            [colors3[2]], ['delta t (between 2 logged samples)'])
-        if data_plot.finalize() is not None: plots.append(data_plot)
+            # sampling regularity
+            data_plot = DataPlot(data, plot_config, 'sensor_accel_fifo', y_range=Range1d(0, 25e3),
+                                 y_axis_label='[us]',
+                                 title=f'Sampling Regularity of Sensor Data (FIFO, IMU{instance})',
+                                 plot_height='small',
+                                 changed_params=changed_params,
+                                 x_range=x_range, topic_instance=instance)
+            sensor_accel_fifo = ulog.get_dataset('sensor_accel_fifo').data
+            sampling_diff = np.diff(sensor_accel_fifo['timestamp'])
+            min_sampling_diff = np.amin(sampling_diff)
+            plot_dropouts(data_plot.bokeh_plot, ulog.dropouts, min_sampling_diff)
+            data_plot.add_graph([lambda data: ('timediff', np.append(sampling_diff, 0))],
+                                [colors3[2]], ['delta t (between 2 logged samples)'])
+            if data_plot.finalize() is not None: plots.append(data_plot)
 
     # FIFO gyro
-    if add_virtual_fifo_topic_data(ulog, 'sensor_gyro_fifo'):
-        # Raw data
-        data_plot = DataPlot(data, plot_config, 'sensor_gyro_fifo_virtual',
-                             y_axis_label='[m/s^2]', title='Raw Gyro (FIFO)',
-                             plot_height='small', changed_params=changed_params,
-                             x_range=x_range)
-        data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
-        data_plot.add_graph([
-            lambda data: ('x', np.rad2deg(data['x'])),
-            lambda data: ('y', np.rad2deg(data['y'])),
-            lambda data: ('z', np.rad2deg(data['z']))],
-                            colors3, ['X', 'Y', 'Z'])
-        if data_plot.finalize() is not None: plots.append(data_plot)
+    for instance in range(3):
+        if add_virtual_fifo_topic_data(ulog, 'sensor_gyro_fifo', instance):
+            # Raw data
+            data_plot = DataPlot(data, plot_config, 'sensor_gyro_fifo_virtual',
+                                 y_axis_label='[m/s^2]', title=f'Raw Gyro (FIFO, IMU{instance})',
+                                 plot_height='small', changed_params=changed_params,
+                                 x_range=x_range, topic_instance=instance)
+            data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])
+            data_plot.add_graph([
+                lambda data: ('x', np.rad2deg(data['x'])),
+                lambda data: ('y', np.rad2deg(data['y'])),
+                lambda data: ('z', np.rad2deg(data['z']))],
+                                colors3, ['X', 'Y', 'Z'])
+            if data_plot.finalize() is not None: plots.append(data_plot)
 
-        # power spectral density
-        data_plot = DataPlotSpec(data, plot_config, 'sensor_gyro_fifo_virtual',
-                                 y_axis_label='[Hz]', title='Gyro Power Spectral Density (FIFO)',
-                                 plot_height='normal', x_range=x_range)
-        data_plot.add_graph(['x', 'y', 'z'], ['X', 'Y', 'Z'])
-        if data_plot.finalize() is not None: plots.append(data_plot)
+            # power spectral density
+            data_plot = DataPlotSpec(data, plot_config, 'sensor_gyro_fifo_virtual',
+                                     y_axis_label='[Hz]',
+                                     title=f'Gyro Power Spectral Density (FIFO, IMU{instance})',
+                                     plot_height='normal', x_range=x_range, topic_instance=instance)
+            data_plot.add_graph(['x', 'y', 'z'], ['X', 'Y', 'Z'])
+            if data_plot.finalize() is not None: plots.append(data_plot)
 
 
     # magnetic field strength

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -744,7 +744,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
         if add_virtual_fifo_topic_data(ulog, 'sensor_gyro_fifo', instance):
             # Raw data
             data_plot = DataPlot(data, plot_config, 'sensor_gyro_fifo_virtual',
-                                 y_axis_label='[m/s^2]', title=f'Raw Gyro (FIFO, IMU{instance})',
+                                 y_axis_label='[deg/s]', title=f'Raw Gyro (FIFO, IMU{instance})',
                                  plot_height='small', changed_params=changed_params,
                                  x_range=x_range, topic_instance=instance)
             data_plot.add_graph(['x', 'y', 'z'], colors3, ['X', 'Y', 'Z'])

--- a/app/plot_app/leaflet.py
+++ b/app/plot_app/leaflet.py
@@ -12,7 +12,7 @@ def ulog_to_polyline(ulog, flight_mode_changes):
     """
     def rgb_colors(flight_mode):
         """ flight mode color from a flight mode """
-        if not flight_mode in flight_modes_table: flight_mode = 0
+        if flight_mode not in flight_modes_table: flight_mode = 0
 
         color_str = flight_modes_table[flight_mode][1] # color in form '#ff00aa'
         # increase brightness to match colors with template

--- a/app/plot_app/pid_analysis.py
+++ b/app/plot_app/pid_analysis.py
@@ -416,8 +416,8 @@ def plot_pid_response(trace, data, plot_config, label='Rate'):
 #            y_values = [20]
 #            # add a space to separate it from the line
 #            names = [' {:.0f} ms'.format(response_time*1000)]
-#            source = ColumnDataSource(data=dict(x=np.array([response_time]),
-#                                                names=names, y=y_values))
+#            source = ColumnDataSource(data={'x': np.array([response_time]),
+#                                                'names':names, 'y': y_values})
 #            # plot as text with a fixed screen-space y offset
 #            labels = LabelSet(x='x', y='y', text='names',
 #                              y_units='screen', level='glyph',

--- a/app/plot_app/plotted_tables.py
+++ b/app/plot_app/plotted_tables.py
@@ -504,14 +504,15 @@ def get_changed_parameters(ulog, plot_width):
                 param_colors.append('black' if is_airframe_default else plot_color_red)
         except Exception as error:
             print(type(error), error)
-    param_data = dict(
-        names=param_names,
-        values=param_values,
-        defaults=param_defaults,
-        mins=param_mins,
-        maxs=param_maxs,
-        descriptions=param_descriptions,
-        colors=param_colors)
+    param_data = {
+        'names': param_names,
+        'values': param_values,
+        'defaults': param_defaults,
+        'mins': param_mins,
+        'maxs': param_maxs,
+        'descriptions': param_descriptions,
+        'colors': param_colors
+        }
     source = ColumnDataSource(param_data)
     formatter = HTMLTemplateFormatter(template='<font color="<%= colors %>"><%= value %></font>')
     columns = [
@@ -561,10 +562,11 @@ def get_logged_messages(ulog, plot_width):
 
     log_times, log_times_str, log_levels, log_messages = \
         zip(*messages) if len(messages) > 0 else ([],[],[],[])
-    log_data = dict(
-        times=log_times_str,
-        levels=log_levels,
-        messages=log_messages)
+    log_data = {
+        'times': log_times_str,
+        'levels': log_levels,
+        'messages': log_messages
+        }
     source = ColumnDataSource(log_data)
     columns = [
         TableColumn(field="times", title="Time",

--- a/app/plot_app/plotting.py
+++ b/app/plot_app/plotting.py
@@ -113,7 +113,7 @@ def plot_parameter_changes(p, plots_height, changed_parameters):
         i += 1
 
     if len(names) > 0:
-        source = ColumnDataSource(data=dict(x=timestamps, names=names, y=y_values))
+        source = ColumnDataSource(data={'x': timestamps, 'names': names, 'y': y_values})
 
         # plot as text with a fixed screen-space y offset
         labels = LabelSet(x='x', y='y', text='names',
@@ -164,8 +164,8 @@ def plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states=Non
     # plot flight mode names as labels
     # they're only visible when the mouse is over the plot
     if len(labels_text) > 0:
-        source = ColumnDataSource(data=dict(x=labels_x_pos, text=labels_text,
-                                            y=labels_y_pos, textcolor=labels_color))
+        source = ColumnDataSource(data={'x': labels_x_pos, 'text': labels_text,
+                                        'y': labels_y_pos, 'textcolor': labels_color})
         labels = LabelSet(x='x', y='y', text='text',
                           y_units='screen', level='underlay',
                           source=source, render_mode='canvas',
@@ -181,7 +181,7 @@ def plot_flight_modes_background(data_plot, flight_mode_changes, vtol_states=Non
         code = """
         labels.visible = cb_obj.event_name == "mouseenter";
         """
-        callback = CustomJS(args=dict(labels=labels), code=code)
+        callback = CustomJS(args={'labels': labels}, code=code)
         p.js_on_event(events.MouseEnter, callback)
         p.js_on_event(events.MouseLeave, callback)
 
@@ -272,7 +272,7 @@ def plot_map(ulog, config, map_type='plain', api_key=None, setpoints=False,
 
 
         if map_type == 'google':
-            data_source = ColumnDataSource(data=dict(lat=lat, lon=lon))
+            data_source = ColumnDataSource(data={'lat': lat, 'lon': lon})
 
             lon_center = (np.amin(lon) + np.amax(lon)) / 2
             lat_center = (np.amin(lat) + np.amax(lat)) / 2
@@ -300,7 +300,7 @@ def plot_map(ulog, config, map_type='plain', api_key=None, setpoints=False,
 
             # transform coordinates
             lon, lat = WGS84_to_mercator(lon, lat)
-            data_source = ColumnDataSource(data=dict(lat=lat, lon=lon))
+            data_source = ColumnDataSource(data={'lat': lat, 'lon': lon})
 
             p = figure(tools=TOOLS, active_scroll=ACTIVE_SCROLL_TOOLS)
             p.plot_width = plots_width
@@ -360,7 +360,7 @@ def plot_map(ulog, config, map_type='plain', api_key=None, setpoints=False,
 
 
             lat, lon = map_projection(lat, lon, anchor_lat, anchor_lon)
-            data_source = ColumnDataSource(data=dict(lat=lat, lon=lon))
+            data_source = ColumnDataSource(data={'lat': lat, 'lon': lon})
 
             if bokeh_plot is None:
                 p = figure(tools=TOOLS, active_scroll=ACTIVE_SCROLL_TOOLS,
@@ -391,7 +391,7 @@ def plot_map(ulog, config, map_type='plain', api_key=None, setpoints=False,
                     lon = np.deg2rad(lon)
                     lat, lon = map_projection(lat, lon, anchor_lat, anchor_lon)
 
-                data_source = ColumnDataSource(data=dict(lat=lat, lon=lon))
+                data_source = ColumnDataSource(data={'lat': lat, 'lon': lon})
 
                 p.circle(x='lon', y='lat', source=data_source,
                          line_width=2, size=6, line_color=config['mission_setpoint_color'],
@@ -547,8 +547,8 @@ class DataPlot:
                     y_values = [30] * len(nan_timestamps)
                     # NaN label: add a space to separate it from the line
                     names = [' NaN'] * len(nan_timestamps)
-                    source = ColumnDataSource(data=dict(x=np.array(list(nan_timestamps)),
-                                                        names=names, y=y_values))
+                    source = ColumnDataSource(data={'x': np.array(list(nan_timestamps)),
+                                                    'names': names, 'y': y_values})
                     # plot as text with a fixed screen-space y offset
                     labels = LabelSet(x='x', y='y', text='names',
                                       y_units='screen', level='glyph', text_color=nan_color,
@@ -716,7 +716,7 @@ class DataPlot:
                         ret_val = ret_val + "." + pad(ms, 3);
                     }
                     return ret_val;
-                ''', args={'x_range' : p.x_range})
+                ''', args={'x_range': p.x_range})
 
         # make it possible to hide graphs by clicking on the label
         p.legend.click_policy = "hide"
@@ -765,7 +765,7 @@ class DataPlot2D(DataPlot):
                 if np.count_nonzero(x) == 0 and np.count_nonzero(y) == 0:
                     raise ValueError()
 
-            data_source = ColumnDataSource(data=dict(x=x, y=y))
+            data_source = ColumnDataSource(data={'x': x, 'y': y})
 
             p.line(x="x", y="y", source=data_source, line_width=2,
                    line_color=color, legend_label=legend)

--- a/app/plot_app/plotting.py
+++ b/app/plot_app/plotting.py
@@ -55,14 +55,14 @@ def plot_dropouts(p, dropouts, min_value, show_hover_tooltips=False):
         p.add_tools(HoverTool(tooltips=[('dropout', '@duration ms')],
                               renderers=[quad]))
 
-def add_virtual_fifo_topic_data(ulog, topic_name):
+def add_virtual_fifo_topic_data(ulog, topic_name, instance=0):
     """ adds a virtual topic by expanding the FIFO samples array into individual
         samples, so it can be used for normal plotting.
         new topic name: topic_name+'_virtual'
         :return: True if topic data was added
     """
     try:
-        cur_dataset = copy.deepcopy(ulog.get_dataset(topic_name))
+        cur_dataset = copy.deepcopy(ulog.get_dataset(topic_name, instance))
         cur_dataset.name = topic_name+'_virtual'
         t = cur_dataset.data['timestamp_sample']
         dt = cur_dataset.data['dt']

--- a/app/plot_app/statistics_plots.py
+++ b/app/plot_app/statistics_plots.py
@@ -310,7 +310,7 @@ class StatisticsPlots:
 
 
         # show the release versions as text markers
-        release_dict = dict(dates=[], tags=[], y=[], y_offset=[])
+        release_dict = {'dates': [], 'tags': [], 'y': [], 'y_offset': []}
         max_logs_dates = self._public_logs_dates # defines range limits of the plot
         if len(max_logs_dates) > 0:
             first_date = max_logs_dates[0]
@@ -358,7 +358,7 @@ class StatisticsPlots:
                     source.trigger('change');
                 """
 # FIXME: this is broken on bokeh 0.12.12
-#                p.y_range.callback = CustomJS(args=dict(source=source), code=jscode)
+#                p.y_range.callback = CustomJS(args={'source': source}, code=jscode)
 
         self._setup_plot(p, 'large')
 

--- a/app/tornado_handlers/download.py
+++ b/app/tornado_handlers/download.py
@@ -85,7 +85,7 @@ class DownloadHandler(TornadoRequestHandlerBase):
 
                 def kml_colors(flight_mode):
                     """ flight mode colors for KML file """
-                    if not flight_mode in flight_modes_table: flight_mode = 0
+                    if flight_mode not in flight_modes_table: flight_mode = 0
 
                     color_str = flight_modes_table[flight_mode][1][1:] # color in form 'ff00aa'
 


### PR DESCRIPTION
v6x can easily log the FIFO data of all the IMUs, plotting all of them for comparison is really useful.

Example:
![fifo_all3_imus](https://github.com/PX4/flight_review/assets/14822839/d8685096-17b2-424a-8eb2-2fe313095882)

Also fixed the gyro label found in https://github.com/PX4/flight_review/pull/239