### PR TITLE
Tailsitter : correct rate setpoint to match rate for tailsitter

### DIFF
--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -248,18 +248,12 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         if is_vtol_tailsitter:
-            # if tailsitter_rates[axis] is not None:
-            #     data_plot.add_graph([lambda data: (axis+'_q',
-            #                                        np.rad2deg(tailsitter_rates[axis]))],
-            #                         colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
-            #     data_plot.add_graph([lambda data: (axis, np.rad2deg(tailsitter_rates_setpoint[axis]))],
-            #                         colors3[1:2], [axis_name+' Rate Setpoint'],
-            #                         mark_nan=True, use_step_lines=True)
-            data_plot.add_graph([lambda data: (axis+'_q',
+            if tailsitter_rates[axis] is not None:
+                data_plot.add_graph([lambda data: (axis+'_q',
                                 np.rad2deg(tailsitter_rates[axis]))],
                                 colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
-            data_plot.change_dataset('vehicle_rates_setpoint')
-            data_plot.add_graph([lambda data: (axis, np.rad2deg(tailsitter_rates_setpoint[axis]))],
+                data_plot.change_dataset('vehicle_rates_setpoint')
+                data_plot.add_graph([lambda data: (axis, np.rad2deg(tailsitter_rates_setpoint[axis]))],
                                 colors3[1:2], [axis_name+' Rate Setpoint'],
                                 mark_nan=True, use_step_lines=True)
         else:

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -207,7 +207,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # VTOL tailistter orientation conversion, if relevant
     if is_vtol_tailsitter:
-        [tailsitter_attitude, tailsitter_rates, tailsitter_rates_setpoint] = tailsitter_orientation(ulog, vtol_states)
+        [tailsitter_attitude, tailsitter_rates, tailsitter_rates_setpoint] = tailsitter_orientation(
+            ulog, vtol_states)
 
     # Roll/Pitch/Yaw angle & angular rate
     for index, axis in enumerate(['roll', 'pitch', 'yaw']):
@@ -253,7 +254,8 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                                 np.rad2deg(tailsitter_rates[axis]))],
                                 colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
                 data_plot.change_dataset('vehicle_rates_setpoint')
-                data_plot.add_graph([lambda data: (axis, np.rad2deg(tailsitter_rates_setpoint[axis]))],
+                data_plot.add_graph([lambda data: (axis, np.rad2deg(
+                                tailsitter_rates_setpoint[axis]))],
                                 colors3[1:2], [axis_name+' Rate Setpoint'],
                                 mark_nan=True, use_step_lines=True)
         else:

--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -207,7 +207,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # VTOL tailistter orientation conversion, if relevant
     if is_vtol_tailsitter:
-        [tailsitter_attitude, tailsitter_rates] = tailsitter_orientation(ulog, vtol_states)
+        [tailsitter_attitude, tailsitter_rates, tailsitter_rates_setpoint] = tailsitter_orientation(ulog, vtol_states)
 
     # Roll/Pitch/Yaw angle & angular rate
     for index, axis in enumerate(['roll', 'pitch', 'yaw']):
@@ -248,18 +248,28 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                              plot_height='small', changed_params=changed_params,
                              x_range=x_range)
         if is_vtol_tailsitter:
-            if tailsitter_rates[axis] is not None:
-                data_plot.add_graph([lambda data: (axis+'_q',
-                                                   np.rad2deg(tailsitter_rates[axis]))],
-                                    colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
+            # if tailsitter_rates[axis] is not None:
+            #     data_plot.add_graph([lambda data: (axis+'_q',
+            #                                        np.rad2deg(tailsitter_rates[axis]))],
+            #                         colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
+            #     data_plot.add_graph([lambda data: (axis, np.rad2deg(tailsitter_rates_setpoint[axis]))],
+            #                         colors3[1:2], [axis_name+' Rate Setpoint'],
+            #                         mark_nan=True, use_step_lines=True)
+            data_plot.add_graph([lambda data: (axis+'_q',
+                                np.rad2deg(tailsitter_rates[axis]))],
+                                colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
+            data_plot.change_dataset('vehicle_rates_setpoint')
+            data_plot.add_graph([lambda data: (axis, np.rad2deg(tailsitter_rates_setpoint[axis]))],
+                                colors3[1:2], [axis_name+' Rate Setpoint'],
+                                mark_nan=True, use_step_lines=True)
         else:
             data_plot.add_graph([lambda data: (axis+'speed',
                                                np.rad2deg(data[rate_field_names[index]]))],
                                 colors3[0:1], [axis_name+' Rate Estimated'], mark_nan=True)
-        data_plot.change_dataset('vehicle_rates_setpoint')
-        data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
-                            colors3[1:2], [axis_name+' Rate Setpoint'],
-                            mark_nan=True, use_step_lines=True)
+            data_plot.change_dataset('vehicle_rates_setpoint')
+            data_plot.add_graph([lambda data: (axis, np.rad2deg(data[axis]))],
+                                colors3[1:2], [axis_name+' Rate Setpoint'],
+                                mark_nan=True, use_step_lines=True)
         axis_letter = axis[0].upper()
         rate_int_limit = '(*100)'
         # this param is MC/VTOL only (it will not exist on FW)

--- a/app/plot_app/vtol_tailsitter.py
+++ b/app/plot_app/vtol_tailsitter.py
@@ -81,7 +81,7 @@ def tailsitter_orientation(ulog, vtol_states):
         w_y = cur_dataset.data['xyz[2]']
         w_t = cur_dataset.data['timestamp']
 
-        #fw rates and setpoints(roll and yaw swap, roll is negative axis)        
+        # fw rates and setpoints(roll and yaw swap, roll is negative axis)
         w_r_fw = w_y*-1
         w_y_fw = w_r*1 # *1 to get python to copy not reference
         # temporary variables for storing VTOL states
@@ -113,19 +113,18 @@ def tailsitter_orientation(ulog, vtol_states):
     except (KeyError, IndexError) as error:
         vtol_rates = {'roll': None, 'pitch': None, 'yaw': None}
         print("ERROR: Tailsitter rate ")
-        
 
      # correct rates setpoint for VTOL tailsitter in FW mode
     try:
-      
+
         setp_dataset = ulog.get_dataset('vehicle_rates_setpoint')
         setp_r = setp_dataset.data['roll']
         setp_p = setp_dataset.data['pitch']
         setp_y = setp_dataset.data['yaw']
         w_t = setp_dataset.data['timestamp']
-     
+
         # fw setpoints(roll and yaw swap, roll is negative axis)
-        
+
         setp_r_fw = setp_y*-1
         setp_y_fw = setp_r*1
         # temporary variables for storing VTOL states
@@ -138,7 +137,7 @@ def tailsitter_orientation(ulog, vtol_states):
         # states: 1=transition, 2=FW, 3=MC
         # if in FW mode then used FW conversions
             if is_vtol_fw:
-                fw_end = i[0]               
+                fw_end = i[0]
                 setp_r[np.logical_and(w_t > fw_start, w_t < fw_end)] = \
                                 setp_r_fw[np.logical_and(w_t > fw_start, w_t < fw_end)]
                 setp_y[np.logical_and(w_t > fw_start, w_t < fw_end)] = \

--- a/app/plot_app/vtol_tailsitter.py
+++ b/app/plot_app/vtol_tailsitter.py
@@ -81,7 +81,7 @@ def tailsitter_orientation(ulog, vtol_states):
         w_y = cur_dataset.data['xyz[2]']
         w_t = cur_dataset.data['timestamp']
 
-        # fw rates (roll and yaw swap, roll is negative axis)
+        #fw rates and setpoints(roll and yaw swap, roll is negative axis)        
         w_r_fw = w_y*-1
         w_y_fw = w_r*1 # *1 to get python to copy not reference
         # temporary variables for storing VTOL states
@@ -112,5 +112,52 @@ def tailsitter_orientation(ulog, vtol_states):
 
     except (KeyError, IndexError) as error:
         vtol_rates = {'roll': None, 'pitch': None, 'yaw': None}
+        print("ERROR: Tailsitter rate ")
+        
 
-    return [vtol_attitude, vtol_rates]
+     # correct rates setpoint for VTOL tailsitter in FW mode
+    try:
+      
+        setp_dataset = ulog.get_dataset('vehicle_rates_setpoint')
+        setp_r = setp_dataset.data['roll']
+        setp_p = setp_dataset.data['pitch']
+        setp_y = setp_dataset.data['yaw']
+        w_t = setp_dataset.data['timestamp']
+     
+        # fw setpoints(roll and yaw swap, roll is negative axis)
+        
+        setp_r_fw = setp_y*-1
+        setp_y_fw = setp_r*1
+        # temporary variables for storing VTOL states
+
+        is_vtol_fw = False
+        fw_start = np.nan
+        fw_end = np.nan
+
+        for i in vtol_states:
+        # states: 1=transition, 2=FW, 3=MC
+        # if in FW mode then used FW conversions
+            if is_vtol_fw:
+                fw_end = i[0]               
+                setp_r[np.logical_and(w_t > fw_start, w_t < fw_end)] = \
+                                setp_r_fw[np.logical_and(w_t > fw_start, w_t < fw_end)]
+                setp_y[np.logical_and(w_t > fw_start, w_t < fw_end)] = \
+                                setp_y_fw[np.logical_and(w_t > fw_start, w_t < fw_end)]
+                is_vtol_fw = False
+            if i[1] == 2:
+                fw_start = i[0]
+                is_vtol_fw = True
+
+        # if flight ended as FW, convert the final data segment to FW
+        if is_vtol_fw:
+            setp_r[quat_t > fw_start] = setp_r_fw[quat_t > fw_start]
+            setp_y[quat_t > fw_start] = setp_y_fw[quat_t > fw_start]
+
+        vtol_rates_setpoint = {'roll': setp_r, 'pitch': setp_p, 'yaw': setp_y}
+
+    except (KeyError, IndexError) as error:
+        vtol_rates_setpoint = {'roll': None, 'pitch': None, 'yaw': None}
+        print("ERROR: Tailsitter rate setpoint")
+
+
+    return [vtol_attitude, vtol_rates, vtol_rates_setpoint]


### PR DESCRIPTION
I was analysing some logs for a quadtailsitter without control surfaces that i'm developing, and I notice that even though the angle tracking of roll was quite good, the plots for the rates did not make sense
![Screenshot from 2024-03-21 13-51-43](https://github.com/PX4/flight_review/assets/149970685/6c296b2d-4683-4503-94f1-a1fe0411f97d)
![rollrate_wrong](https://github.com/PX4/flight_review/assets/149970685/ba32ca13-224a-410c-bd83-36e9799a9d32)

Here the [complete logs](https://review.px4.io/plot_app?log=d21b119d-21dc-45b4-9380-481d8e2cf5cb) for reference 
By looking into the `configured_plots.py` I saw that if the vehicle is a tailsitter angles and rates are reassigned to be plotted in a more consisten way for the instants that drone is flying in fixed wing:

- yaw -> -roll
- roll -> yaw

but this is not applied to the rates setpoint, so the result is that on the rollrate plot , for example , the data shown are:

- in MC 

1. Roll rate
2. Roll rate setpoint

- in FW

1.  Inverse of yaw rate
2. Roll rate setpoint

What I did was simply remapping also the setpoints in fixed wing so to have in the same plot
- in FW

1.  Inverse of yaw rate
2.  Inverse of yaw rate setpoint
![rollrate_new](https://github.com/PX4/flight_review/assets/149970685/c3362eb6-cecb-41f4-9c2f-6d590b7910e0)

Tracking is still not perfect, but that's a problem with the simluation.
Aslo plot of yaw rate makes more sense:

- Old
![yawrate_wrong](https://github.com/PX4/flight_review/assets/149970685/f242ee86-3e7a-4709-a6e8-ad53bf0323ec)

- New
![yawrate_new](https://github.com/PX4/flight_review/assets/149970685/d83ca927-09cc-4593-8a49-474cf0bfa973)

Honestly this to me was very confusing, since I tried to find a reason for the behavior of correct angles but completely wrong rate control. In this way it makes more sense, so you could easily see if the rate controller is good at tracking. I think this was the way it was handled in the past, since I saw some old logs review that did not have this problem and I think is related on the new control approach.
I'm conscious that the code may need other adjustments, since probably I'm not considering some cases (did not look into PID analysis for now). I opened this PR just to understand if this was actually a problem or the was a specific reason for this

