### PR TITLE
app: fix pylint 'possible variable use before assignment' error

### DIFF
--- a/app/serve.py
+++ b/app/serve.py
@@ -100,6 +100,7 @@ server_kwargs['http_server_kwargs'] = {'max_buffer_size': 300 * 1024 * 1024}
 show_ulog_file = False
 show_3d_page = False
 show_pid_analysis_page = False
+ulog_file = ''
 if args.file is not None:
     ulog_file = os.path.abspath(args.file)
     show_ulog_file = True

--- a/app/tornado_handlers/three_d.py
+++ b/app/tornado_handlers/three_d.py
@@ -119,6 +119,7 @@ class ThreeDHandler(TornadoRequestHandlerBase):
         # - altitude requires an offset (to match the GPS data)
         # - it's worse for some logs where the estimation is bad -> acro flights
         #   (-> add both: user-selectable between GPS & estimated trajectory?)
+        start_timestamp = 0
         for i in range(len(gps_pos.data['timestamp'])):
             t = gps_pos.data['timestamp'][i] + utc_offset
             utctimestamp = datetime.datetime.utcfromtimestamp(t/1.e6).replace(


### PR DESCRIPTION
Fixes these (new) pylint errors:
```
~/work/flight_review/flight_review/app ~/work/flight_review/flight_review
************* Module three_d
tornado_handlers/three_d.py:133:45: E0606: Possibly using variable 'start_timestamp' before assignment (possibly-used-before-assignment)
************* Module serve
serve.py:149:39: E0606: Possibly using variable 'ulog_file' before assignment (possibly-used-before-assignment)
```