### PR TITLE
Fix uploading of currupt logs

### DIFF
--- a/app/plot_app/helper.py
+++ b/app/plot_app/helper.py
@@ -314,7 +314,7 @@ def load_ulog_file(file_name):
                   'vehicle_thrust_setpoint', 'vehicle_torque_setpoint',
                   'failsafe_flags']
     try:
-        ulog = ULog(file_name, msg_filter, disable_str_exceptions=False)
+        ulog = ULog(file_name, msg_filter, disable_str_exceptions=True)
     except FileNotFoundError:
         print("Error: file %s not found" % file_name)
         raise


### PR DESCRIPTION
Currently any log with a minor corruption will not upload and complain about the log being corrupt. Plotjuggler opens the logs without issue. Allowing string exceptions fixes this.

```
./serve.py --show
/home/alex/.local/lib/python3.10/site-packages/matplotlib/projections/__init__.py:63: UserWarning: Unable to import Axes3D. This may be due to multiple versions of Matplotlib being installed (e.g. as a system package and as a pip package). As a result, the 3D projection is not available.
  warnings.warn("Unable to import Axes3D. This may be due to multiple versions of "
Moving uploaded file to /home/alex/flight_review/app/plot_app/../../data/log_files/10c53e34-3767-493b-ba84-20332f3d225f.ulg
Traceback (most recent call last):
  File "/home/alex/flight_review/app/plot_app/helper.py", line 317, in load_ulog_file
    ulog = ULog(file_name, msg_filter, disable_str_exceptions=False)
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/core.py", line 137, in __init__
    self._load_file(log_file, message_name_filter_list, parse_header_only)
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/core.py", line 836, in _load_file
    self._read_file_definitions()
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/core.py", line 886, in _read_file_definitions
    msg_info = self._MessageInfo(data, header, is_info_multiple=True)
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/core.py", line 563, in __init__
    self.value = ULog.parse_string(data[1+key_len:])
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/core.py", line 91, in parse_string
    ret = _parse_string(cstr)
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/core.py", line 17, in _parse_string
    return str(cstr, 'utf-8', errors)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xba in position 152: invalid start byte
400 POST /upload (127.0.0.1): Failed to parse the file. It is most likely corrupt.
400 POST /upload (127.0.0.1) 153.78ms
```