### PR TITLE
fix power plot: check if dataset is None

### DIFF
--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -884,7 +884,7 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
                         ['Battery Voltage [V]',
                          'Battery Current [A]', 'Discharged Amount [mAh / 100]',
                          'Battery remaining [0=empty, 10=full]'])
-    if 'internal_resistance_estimate' in data_plot.dataset.data:
+    if data_plot.dataset is not None and 'internal_resistance_estimate' in data_plot.dataset.data:
         data_plot.add_graph(['ocv_estimate', lambda data: ('internal_resistance_estimate',
                               data['internal_resistance_estimate']*1000)],
                             colors8[4:6],


### PR DESCRIPTION
This happens if the log does not contain the battery_status topic

Example log: https://review.px4.io/plot_app?log=e4549fd2-32c6-43f1-8f1c-6b3db7c08c25

Fixes #315