### PR TITLE
browse: move search and pagination to SQL

### DIFF
--- a/app/plot_app/templates/browse.html
+++ b/app/plot_app/templates/browse.html
@@ -48,9 +48,10 @@
                 "search": {{ initial_search }}
             },
 {% endif %}
+            "pageLength": 25,
             "order": [[1, 'desc']],
             "ordering": true,
-            "lengthMenu": [10, 25, 50, 75, 100],
+            "lengthMenu": [25, 50, 75, 100],
 
             "columns": [
                 { "orderable": false }, /* row number */

--- a/app/plot_app/templates/browse.html
+++ b/app/plot_app/templates/browse.html
@@ -68,6 +68,7 @@
                 "infoFiltered": "<br>(filtered from _MAX_ total entries)",
             },
             "serverSide": true,
+            "searchDelay": 500,
             "ajax": "browse_data_retrieval",
         });
         var table = $('#logs_table').DataTable();

--- a/app/setup_db.py
+++ b/app/setup_db.py
@@ -133,6 +133,14 @@ with con:
             cur.execute("ALTER TABLE LogsGenerated ADD COLUMN StartTime INT DEFAULT 0")
 
 
+    # Indexes for browse/search performance
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_logs_public_source_date "
+                "ON Logs(Public, Source, Date DESC)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_logsgenerated_hardware "
+                "ON LogsGenerated(Hardware)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_logsgenerated_software "
+                "ON LogsGenerated(Software)")
+
     # Vehicle table (contains information about a vehicle)
     cur.execute("PRAGMA table_info('Vehicle')")
     columns = cur.fetchall()

--- a/app/tornado_handlers/browse.py
+++ b/app/tornado_handlers/browse.py
@@ -241,9 +241,10 @@ class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
                         ]
         sql_order = ' ORDER BY Logs.Date DESC'
         if ordering_col[order_ind] != '':
-            sql_order = ' ORDER BY ' + ordering_col[order_ind]
-            if order_dir == 'desc':
-                sql_order += ' DESC'
+            col = ordering_col[order_ind]
+            direction = ' DESC' if order_dir == 'desc' else ''
+            # push NULLs to the end regardless of sort direction
+            sql_order = f' ORDER BY {col} IS NULL, {col}{direction}'
 
         # build WHERE with optional search
         where = 'WHERE ' + _BASE_WHERE

--- a/app/tornado_handlers/browse.py
+++ b/app/tornado_handlers/browse.py
@@ -2,7 +2,6 @@
 Tornado handler for the browse page
 """
 from __future__ import print_function
-import collections
 import sys
 import os
 import re
@@ -29,6 +28,26 @@ _TAG_PREFIX_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
+# columns searchable via SQL LIKE
+_SEARCH_COLUMNS = [
+    'Logs.Description',
+    'LogsGenerated.MavType',
+    'LogsGenerated.Hardware',
+    'LogsGenerated.Software',
+    'LogsGenerated.SoftwareVersion',
+    'LogsGenerated.UUID',
+]
+
+_BASE_WHERE = 'Logs.Public = 1 AND NOT Logs.Source = ?'
+_BASE_PARAMS = ['CI']
+
+_SELECT_COLS = ('SELECT Logs.Id, Logs.Date, '
+                '       Logs.Description, Logs.WindSpeed, '
+                '       Logs.Rating, Logs.VideoUrl, '
+                '       LogsGenerated.* '
+                'FROM Logs '
+                '   LEFT JOIN LogsGenerated on Logs.Id=LogsGenerated.Id ')
+
 def format_duration(seconds: int) -> str:
     """ Format duration in seconds to HhMmSs string """
     try:
@@ -41,6 +60,154 @@ def format_duration(seconds: int) -> str:
     if h: return f"{h}h{m}m{s}s"
     if m: return f"{m}m{s}s"
     return f"{s}s"
+
+
+def _is_hashish(q: str) -> bool:
+    """ return true if the string looks like a git hash """
+    if len(q) < 4:
+        return False
+    hex_chars = set('0123456789abcdef')
+    return all(c in hex_chars for c in q)
+
+def _is_tagish(q: str) -> bool:
+    """ return true if the string looks like a git tag """
+    if not q or q[0] not in ('v', 'V'):
+        return False
+    return bool(_TAG_PREFIX_RE.match(q))
+
+
+def _build_search_clause(search_str):
+    """Build SQL WHERE clause and params for a search string.
+
+    Returns (sql_fragment, params) where sql_fragment is like
+    '(col1 LIKE ? OR col2 LIKE ? ...)' and params is a list of
+    bound values.
+    """
+    if not search_str:
+        return '', []
+
+    hash_mode = _is_hashish(search_str)
+    tag_mode = _is_tagish(search_str)
+
+    if hash_mode or tag_mode:
+        # prefix match on software version columns only
+        pattern = search_str + '%'
+        prefix_cols = ['LogsGenerated.Software', 'LogsGenerated.SoftwareVersion']
+        clauses = [f'{col} LIKE ?' for col in prefix_cols]
+        # also allow substring match on all columns as fallback
+        sub_pattern = '%' + search_str + '%'
+        clauses += [f'{col} LIKE ?' for col in _SEARCH_COLUMNS]
+        params = [pattern] * len(prefix_cols) + [sub_pattern] * len(_SEARCH_COLUMNS)
+    else:
+        pattern = '%' + search_str + '%'
+        clauses = [f'{col} LIKE ?' for col in _SEARCH_COLUMNS]
+        params = [pattern] * len(_SEARCH_COLUMNS)
+
+    return '(' + ' OR '.join(clauses) + ')', params
+
+
+def _get_columns_from_tuple(db_tuple, counter, all_overview_imgs, con, cur):
+    """ load the display columns from a db_tuple """
+
+    db_data = DBDataJoin()
+    log_id = db_tuple[0]
+    log_date = db_tuple[1].strftime('%Y-%m-%d')
+    db_data.description = db_tuple[2]
+    db_data.feedback = ''
+    db_data.type = ''
+    db_data.wind_speed = db_tuple[3]
+    db_data.rating = db_tuple[4]
+    db_data.video_url = db_tuple[5]
+    generateddata_log_id = db_tuple[6]
+    if log_id != generateddata_log_id:
+        print('Join failed, loading and updating data')
+        db_data_gen = get_generated_db_data_from_log(log_id, con, cur)
+        if db_data_gen is None:
+            return None
+        db_data.add_generated_db_data_from_log(db_data_gen)
+    else:
+        db_data.duration_s = db_tuple[7]
+        db_data.mav_type = db_tuple[8]
+        db_data.estimator = db_tuple[9]
+        db_data.sys_autostart_id = db_tuple[10]
+        db_data.sys_hw = db_tuple[11]
+        db_data.ver_sw = db_tuple[12]
+        db_data.num_logged_errors = db_tuple[13]
+        db_data.num_logged_warnings = db_tuple[14]
+        db_data.flight_modes = \
+            {int(x) for x in db_tuple[15].split(',') if len(x) > 0}
+        db_data.ver_sw_release = db_tuple[16]
+        db_data.vehicle_uuid = db_tuple[17]
+        db_data.flight_mode_durations = \
+           [tuple(map(int, x.split(':'))) for x in db_tuple[18].split(',') if len(x) > 0]
+        db_data.start_time_utc = db_tuple[19]
+
+    # bring it into displayable form
+    ver_sw = db_data.ver_sw
+    if len(ver_sw) > 10:
+        ver_sw = ver_sw[:6]
+    if len(db_data.ver_sw_release) > 0:
+        try:
+            release_split = db_data.ver_sw_release.split()
+            release_type = int(release_split[1])
+            if release_type == 255: # it's a release
+                ver_sw = release_split[0]
+        except:
+            pass
+    airframe_data = get_airframe_data(db_data.sys_autostart_id)
+    if airframe_data is None:
+        airframe = db_data.sys_autostart_id
+    else:
+        airframe = airframe_data['name']
+
+    flight_modes = ', '.join([flight_modes_table[x][0]
+                              for x in db_data.flight_modes if x in
+                              flight_modes_table])
+
+    duration_str = format_duration(db_data.duration_s)
+
+    start_time_str = 'N/A'
+    if db_data.start_time_utc != 0:
+        try:
+            start_datetime = datetime.fromtimestamp(db_data.start_time_utc)
+            start_time_str = start_datetime.strftime("%Y-%m-%d %H:%M")
+        except ValueError as value_error:
+            # bogus date
+            print(value_error)
+
+    rounded_div_class = "h-100 w-100 bg-body-secondary rounded overflow-hidden"
+    image_col_class = "object-fit-cover d-block"
+    overview_image_filename = f"{log_id}.png"
+    if overview_image_filename in all_overview_imgs:
+        image_col = f"""
+            <div class="">
+                <img class="map_overview {image_col_class}"
+                    src="/overview_img/{overview_image_filename}"
+                    loading="lazy" decoding="async" />
+            </div>
+        """
+    else:
+        image_col = f"""
+            <div class="{rounded_div_class}" style="width:60px;">
+                <div class="no_map_overview text-warning">
+                    No Image Preview
+                </div>
+            </div>
+        """
+
+    return [
+        counter,
+        f'<a href="plot_app?log={log_id}">{log_date}</a>',
+        image_col,
+        db_data.mav_type,
+        airframe,
+        db_data.sys_hw,
+        ver_sw,
+        duration_str,
+        start_time_str,
+        flight_modes
+    ]
+
 
 #pylint: disable=abstract-method
 class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
@@ -55,246 +222,69 @@ class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
         data_length = int(self.get_argument('length'))
         draw_counter = int(self.get_argument('draw'))
 
-        json_output = {}
-        json_output['draw'] = draw_counter
+        json_output = dict(draw=draw_counter, data=[])
 
-
-        # get the logs (but only the public ones)
         con = get_db_connection()
         cur = con.cursor()
 
-        sql_order = ' ORDER BY Date DESC'
-
-        ordering_col = ['',#table row number
-                        'Logs.Date',
-                        '',#Overview - img
-                        'Logs.Description',
-                        'LogsGenerated.MavType',
-                        '',#Airframe - not from DB
-                        'LogsGenerated.Hardware',
-                        'LogsGenerated.Software',
-                        'LogsGenerated.Duration',
-                        'LogsGenerated.StartTime',
-                        '',#Rating
-                        'LogsGenerated.NumLoggedErrors',
-                        '' #FlightModes
+        # build ORDER BY — indices must match the DataTables columns config
+        ordering_col = ['',                          # 0: row number
+                        'Logs.Date',                 # 1: Uploaded
+                        '',                          # 2: Overview (image)
+                        'LogsGenerated.MavType',     # 3: Type
+                        '',                          # 4: Airframe (not orderable)
+                        'LogsGenerated.Hardware',    # 5: Hardware
+                        'LogsGenerated.Software',    # 6: Software
+                        'LogsGenerated.Duration',    # 7: Duration
+                        'LogsGenerated.StartTime',   # 8: Start Time
+                        '',                          # 9: Flight Modes (not orderable)
                         ]
+        sql_order = ' ORDER BY Logs.Date DESC'
         if ordering_col[order_ind] != '':
             sql_order = ' ORDER BY ' + ordering_col[order_ind]
             if order_dir == 'desc':
                 sql_order += ' DESC'
 
-        cur.execute('SELECT Logs.Id, Logs.Date, '
-                    '       Logs.Description, Logs.WindSpeed, '
-                    '       Logs.Rating, Logs.VideoUrl, '
-                    '       LogsGenerated.* '
-                    'FROM Logs '
-                    '   LEFT JOIN LogsGenerated on Logs.Id=LogsGenerated.Id '
-                    'WHERE Logs.Public = 1 AND NOT Logs.Source = "CI" '
-                    +sql_order)
+        # build WHERE with optional search
+        where = 'WHERE ' + _BASE_WHERE
+        params = list(_BASE_PARAMS)
 
-        # pylint: disable=invalid-name
-        Columns = collections.namedtuple("Columns", "columns search_only_columns")
+        search_clause, search_params = _build_search_clause(search_str)
+        if search_clause:
+            where += ' AND ' + search_clause
+            params += search_params
 
-        def get_columns_from_tuple(db_tuple, counter, all_overview_imgs):
-            """ load the columns (list of strings) from a db_tuple
-            """
+        # total records (unfiltered)
+        cur.execute('SELECT COUNT(*) FROM Logs WHERE ' + _BASE_WHERE, _BASE_PARAMS)
+        json_output['recordsTotal'] = cur.fetchone()[0]
 
-            db_data = DBDataJoin()
-            log_id = db_tuple[0]
-            log_date = db_tuple[1].strftime('%Y-%m-%d')
-            db_data.description = db_tuple[2]
-            db_data.feedback = ''
-            db_data.type = ''
-            db_data.wind_speed = db_tuple[3]
-            db_data.rating = db_tuple[4]
-            db_data.video_url = db_tuple[5]
-            generateddata_log_id = db_tuple[6]
-            if log_id != generateddata_log_id:
-                print('Join failed, loading and updating data')
-                db_data_gen = get_generated_db_data_from_log(log_id, con, cur)
-                if db_data_gen is None:
-                    return None
-                db_data.add_generated_db_data_from_log(db_data_gen)
-            else:
-                db_data.duration_s = db_tuple[7]
-                db_data.mav_type = db_tuple[8]
-                db_data.estimator = db_tuple[9]
-                db_data.sys_autostart_id = db_tuple[10]
-                db_data.sys_hw = db_tuple[11]
-                db_data.ver_sw = db_tuple[12]
-                db_data.num_logged_errors = db_tuple[13]
-                db_data.num_logged_warnings = db_tuple[14]
-                db_data.flight_modes = \
-                    {int(x) for x in db_tuple[15].split(',') if len(x) > 0}
-                db_data.ver_sw_release = db_tuple[16]
-                db_data.vehicle_uuid = db_tuple[17]
-                db_data.flight_mode_durations = \
-                   [tuple(map(int, x.split(':'))) for x in db_tuple[18].split(',') if len(x) > 0]
-                db_data.start_time_utc = db_tuple[19]
+        # filtered count
+        cur.execute('SELECT COUNT(*) FROM Logs '
+                    'LEFT JOIN LogsGenerated on Logs.Id=LogsGenerated.Id '
+                    + where, params)
+        records_filtered = cur.fetchone()[0]
+        json_output['recordsFiltered'] = records_filtered
 
-            # bring it into displayable form
-            ver_sw = db_data.ver_sw
-            if len(ver_sw) > 10:
-                ver_sw = ver_sw[:6]
-            if len(db_data.ver_sw_release) > 0:
-                try:
-                    release_split = db_data.ver_sw_release.split()
-                    release_type = int(release_split[1])
-                    if release_type == 255: # it's a release
-                        ver_sw = release_split[0]
-                except:
-                    pass
-            airframe_data = get_airframe_data(db_data.sys_autostart_id)
-            if airframe_data is None:
-                airframe = db_data.sys_autostart_id
-            else:
-                airframe = airframe_data['name']
-
-            flight_modes = ', '.join([flight_modes_table[x][0]
-                                      for x in db_data.flight_modes if x in
-                                      flight_modes_table])
-
-            duration_str = format_duration(db_data.duration_s)
-
-            start_time_str = 'N/A'
-            if db_data.start_time_utc != 0:
-                try:
-                    start_datetime = datetime.fromtimestamp(db_data.start_time_utc)
-                    start_time_str = start_datetime.strftime("%Y-%m-%d %H:%M")
-                except ValueError as value_error:
-                    # bogus date
-                    print(value_error)
-
-            # make sure to break long descriptions w/o spaces (otherwise they
-            # mess up the layout)
-            # disabled description on browse page on 2025-09-26
-            # description = html_long_word_force_break(db_data.description)
-
-            search_only_columns = []
-
-            if db_data.ver_sw is not None:
-                search_only_columns.append(db_data.ver_sw)
-
-            if db_data.ver_sw_release is not None:
-                search_only_columns.append(db_data.ver_sw_release)
-
-            if db_data.vehicle_uuid is not None:
-                search_only_columns.append(db_data.vehicle_uuid)
-
-            rounded_div_class = "h-100 w-100 bg-body-secondary rounded overflow-hidden"
-            image_col_class = "object-fit-cover d-block"
-            overview_image_filename = f"{log_id}.png"
-            if overview_image_filename in all_overview_imgs:
-                image_col = f"""
-                    <div class="">
-                        <img class="map_overview {image_col_class}"
-                            src="/overview_img/{overview_image_filename}"
-                            loading="lazy" decoding="async" />
-                    </div>
-                """
-            else:
-                image_col = f"""
-                    <div class="{rounded_div_class}" style="width:60px;">
-                        <div class="no_map_overview text-warning">
-                            No Image Preview
-                        </div>
-                    </div>
-                """
-
-            return Columns([
-                counter,
-                f'<a href="plot_app?log={log_id}">{log_date}</a>',
-                image_col,
-                db_data.mav_type,
-                airframe,
-                db_data.sys_hw,
-                ver_sw,
-                duration_str,
-                start_time_str,
-                flight_modes
-            ], search_only_columns)
-
-        def is_hashish(q: str) -> bool:
-            """ return true if the string looks like a hash """
-            if len(q) < 4:
-                return False
-            hex_chars = set('0123456789abcdef')
-            return all(c in hex_chars for c in q)
-
-        def is_tagish(q: str) -> bool:
-            """ return true if the string looks like a tag """
-            if not q or q[0] not in ('v', 'V'):
-                return False
-            return bool(_TAG_PREFIX_RE.match(q))
-
-        def _flatten_strings(maybe_list):
-            """ flatten a list of strings or a single string into a single string list """
-            if not maybe_list:
-                return []
-            if isinstance(maybe_list, (list, tuple)):
-                return [str(x) for x in maybe_list]
-            return [str(maybe_list)]
-
-        # need to fetch all here, because we will do more SQL calls while
-        # iterating (having multiple cursor's does not seem to work)
-        db_tuples = cur.fetchall()
-        json_output['recordsTotal'] = len(db_tuples)
-        json_output['data'] = []
+        # fetch only the page we need
         if data_length == -1:
-            data_length = len(db_tuples)
-
-        filtered_counter = 0
-        all_overview_imgs = set(os.listdir(get_overview_img_filepath()))
-        if search_str == '':
-            # speed-up the request by iterating only over the requested items
-            counter = data_start
-            for i in range(data_start, min(data_start + data_length, len(db_tuples))):
-                counter += 1
-
-                columns = get_columns_from_tuple(db_tuples[i], counter, all_overview_imgs)
-                if columns is None:
-                    continue
-
-                json_output['data'].append(columns.columns)
-            filtered_counter = len(db_tuples)
+            limit_clause = ''
         else:
-            counter = 1
-            hash_mode = is_hashish(search_str)
-            tag_mode = is_tagish(search_str)
+            limit_clause = ' LIMIT ? OFFSET ?'
+            params += [data_length, data_start]
 
-            for db_tuple in db_tuples:
-                counter += 1
+        cur.execute(_SELECT_COLS + where + sql_order + limit_clause, params)
+        db_tuples = cur.fetchall()
 
-                columns = get_columns_from_tuple(db_tuple, counter, all_overview_imgs)
-
-                if columns is None:
-                    continue
-
-                visible = _flatten_strings(columns.columns)
-                hidden = _flatten_strings(columns.search_only_columns)
-
-                prefix_hit = False
-                if tag_mode or hash_mode:
-                    for col in hidden:
-                        if col.lower().startswith(search_str):
-                            prefix_hit = True
-                            break
-
-                substring_hit = False
-                if not prefix_hit:
-                    haystack = [s.lower() for s in (visible + hidden)]
-                    substring_hit = any(search_str in s for s in haystack)
-
-                if prefix_hit or substring_hit:
-                    if data_start <= filtered_counter < data_start + data_length:
-                        json_output['data'].append(columns.columns)
-                    filtered_counter += 1
+        all_overview_imgs = set(os.listdir(get_overview_img_filepath()))
+        for i, db_tuple in enumerate(db_tuples):
+            counter = data_start + i + 1
+            columns = _get_columns_from_tuple(
+                db_tuple, counter, all_overview_imgs, con, cur)
+            if columns is not None:
+                json_output['data'].append(columns)
 
         cur.close()
         con.close()
-
-        json_output['recordsFiltered'] = filtered_counter
 
         self.set_header('Content-Type', 'application/json')
         self.write(json.dumps(json_output))

--- a/app/tornado_handlers/browse.py
+++ b/app/tornado_handlers/browse.py
@@ -222,7 +222,7 @@ class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
         data_length = int(self.get_argument('length'))
         draw_counter = int(self.get_argument('draw'))
 
-        json_output = dict(draw=draw_counter, data=[])
+        json_output = {'draw': draw_counter, 'data': []}
 
         con = get_db_connection()
         cur = con.cursor()

--- a/app/tornado_handlers/browse.py
+++ b/app/tornado_handlers/browse.py
@@ -76,31 +76,41 @@ def _is_tagish(q: str) -> bool:
     return bool(_TAG_PREFIX_RE.match(q))
 
 
+def _escape_like(s):
+    """Escape LIKE wildcards so %, _ are matched literally."""
+    return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+
+_MAX_PAGE_SIZE = 500
+
 def _build_search_clause(search_str):
     """Build SQL WHERE clause and params for a search string.
 
     Returns (sql_fragment, params) where sql_fragment is like
-    '(col1 LIKE ? OR col2 LIKE ? ...)' and params is a list of
-    bound values.
+    '(col1 LIKE ? ESCAPE '\\' OR col2 LIKE ? ESCAPE '\\' ...)'
+    and params is a list of bound values.
     """
     if not search_str:
         return '', []
+
+    escaped = _escape_like(search_str)
+    like_expr = "LIKE ? ESCAPE '\\'"
 
     hash_mode = _is_hashish(search_str)
     tag_mode = _is_tagish(search_str)
 
     if hash_mode or tag_mode:
         # prefix match on software version columns only
-        pattern = search_str + '%'
+        pattern = escaped + '%'
         prefix_cols = ['LogsGenerated.Software', 'LogsGenerated.SoftwareVersion']
-        clauses = [f'{col} LIKE ?' for col in prefix_cols]
-        # also allow substring match on all columns as fallback
-        sub_pattern = '%' + search_str + '%'
-        clauses += [f'{col} LIKE ?' for col in _SEARCH_COLUMNS]
-        params = [pattern] * len(prefix_cols) + [sub_pattern] * len(_SEARCH_COLUMNS)
+        clauses = [f'{col} {like_expr}' for col in prefix_cols]
+        # also allow substring match on remaining columns as fallback
+        sub_pattern = '%' + escaped + '%'
+        fallback_cols = [col for col in _SEARCH_COLUMNS if col not in prefix_cols]
+        clauses += [f'{col} {like_expr}' for col in fallback_cols]
+        params = [pattern] * len(prefix_cols) + [sub_pattern] * len(fallback_cols)
     else:
-        pattern = '%' + search_str + '%'
-        clauses = [f'{col} LIKE ?' for col in _SEARCH_COLUMNS]
+        pattern = '%' + escaped + '%'
+        clauses = [f'{col} {like_expr}' for col in _SEARCH_COLUMNS]
         params = [pattern] * len(_SEARCH_COLUMNS)
 
     return '(' + ' OR '.join(clauses) + ')', params
@@ -240,7 +250,7 @@ class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
                         '',                          # 9: Flight Modes (not orderable)
                         ]
         sql_order = ' ORDER BY Logs.Date DESC'
-        if ordering_col[order_ind] != '':
+        if 0 <= order_ind < len(ordering_col) and ordering_col[order_ind] != '':
             col = ordering_col[order_ind]
             direction = ' DESC' if order_dir == 'desc' else ''
             # push NULLs to the end regardless of sort direction
@@ -266,12 +276,12 @@ class BrowseDataRetrievalHandler(tornado.web.RequestHandler):
         records_filtered = cur.fetchone()[0]
         json_output['recordsFiltered'] = records_filtered
 
-        # fetch only the page we need
-        if data_length == -1:
-            limit_clause = ''
-        else:
-            limit_clause = ' LIMIT ? OFFSET ?'
-            params += [data_length, data_start]
+        # fetch only the page we need, enforce a hard max to prevent
+        # unbounded queries from reintroducing the performance problem
+        if data_length <= 0 or data_length > _MAX_PAGE_SIZE:
+            data_length = _MAX_PAGE_SIZE
+        limit_clause = ' LIMIT ? OFFSET ?'
+        params += [data_length, data_start]
 
         cur.execute(_SELECT_COLS + where + sql_order + limit_clause, params)
         db_tuples = cur.fetchall()


### PR DESCRIPTION
The browse page search hangs on production (354k+ logs) because the handler fetches all rows into Python memory and does per-row string matching, HTML generation, and airframe lookups on every request. This moves filtering and pagination into SQL so only the requested page of results is processed in Python.

Search now uses SQL LIKE clauses against the searchable columns (Description, MavType, Hardware, Software, SoftwareVersion, UUID), with prefix matching for git hashes and version tags. Pagination uses LIMIT/OFFSET and totals use COUNT(*) instead of len(fetchall()). Three indexes are added to setup_db.py for the common query patterns.

Also fixes the ordering_col array which was stale (13 entries mapping to an old column layout that included Description, Rating, and NumLoggedErrors, the HTML table only has 10 columns now), adds NULLS LAST to column sorting to prevent empty pages when sorting ascending by LogsGenerated columns, adds a 500ms DataTables searchDelay to debounce keystrokes, and changes the default page size from 10 to 25.

Tested locally against a copy of the production database (354k rows). Search requests complete in ~1-2s in Docker on a laptop vs hanging indefinitely before.