### PR TITLE
vtol_tailsitter: copy cached ulog arrays before in-place mutation

### DIFF
--- a/app/plot_app/vtol_tailsitter.py
+++ b/app/plot_app/vtol_tailsitter.py
@@ -76,9 +76,10 @@ def tailsitter_orientation(ulog, vtol_states):
     # correct angular rates for VTOL tailsitter in FW mode
     try:
         cur_dataset = ulog.get_dataset('vehicle_angular_velocity')
-        w_r = cur_dataset.data['xyz[0]']
-        w_p = cur_dataset.data['xyz[1]']
-        w_y = cur_dataset.data['xyz[2]']
+        # copy to avoid mutating the cached ULog dataset across page reloads
+        w_r = np.copy(cur_dataset.data['xyz[0]'])
+        w_p = np.copy(cur_dataset.data['xyz[1]'])
+        w_y = np.copy(cur_dataset.data['xyz[2]'])
         w_t = cur_dataset.data['timestamp']
 
         # fw rates and setpoints(roll and yaw swap, roll is negative axis)
@@ -118,9 +119,10 @@ def tailsitter_orientation(ulog, vtol_states):
     try:
 
         setp_dataset = ulog.get_dataset('vehicle_rates_setpoint')
-        setp_r = setp_dataset.data['roll']
-        setp_p = setp_dataset.data['pitch']
-        setp_y = setp_dataset.data['yaw']
+        # copy to avoid mutating the cached ULog dataset across page reloads
+        setp_r = np.copy(setp_dataset.data['roll'])
+        setp_p = np.copy(setp_dataset.data['pitch'])
+        setp_y = np.copy(setp_dataset.data['yaw'])
         w_t = setp_dataset.data['timestamp']
 
         # fw setpoints(roll and yaw swap, roll is negative axis)


### PR DESCRIPTION
Fixes #324.

## Root cause

`tailsitter_orientation()` in `app/plot_app/vtol_tailsitter.py` reads the angular-rate and rates-setpoint arrays directly from the cached ULog dataset:

```python
w_r = cur_dataset.data['xyz[0]']
w_y = cur_dataset.data['xyz[2]']
...
w_r[mask] = w_r_fw[mask]
w_y[mask] = w_y_fw[mask]
```

`cur_dataset.data['xyz[0]']` is a reference to the underlying numpy array, and `load_ulog_file()` in `helper.py` is wrapped with `@lru_cache`, so the same ULog object is reused across page loads. The masked assignments mutate the cached arrays in place. On the next refresh the function re-derives `w_r_fw = w_y * -1` and `w_y_fw = w_r * 1` from arrays that already have their FW segments swapped, producing a different (and progressively more corrupted) yaw angular rate each time.

The author was aware of the reference/aliasing trap for the two derived arrays (the `# *1 to get python to copy not reference` comment), but missed that `w_r` and `w_y` themselves are still references into the cache.

The attitude block at the top of the same function is unaffected because it builds new arrays via `np.deg2rad(rpy[:, …])` before mutating.

## Fix

`np.copy()` the source arrays once, right where they're pulled out of the dataset, for both the `vehicle_angular_velocity` and `vehicle_rates_setpoint` blocks. The rest of the masking logic is unchanged.

## Test plan

No test infrastructure exists in this repo (no `tests/` directory, no test runner in CI), so no regression test was added. Manual verification: load any tailsitter VTOL log on a flight-review instance and refresh the page repeatedly — yaw angular rate plot should now be stable instead of drifting.