### PR TITLE
FFT and spectrogram dropout robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ data/certbot
 /.idea
 
 app/private_key/private_key.pem
+
+.claude/

--- a/app/plot_app/pid_analysis.py
+++ b/app/plot_app/pid_analysis.py
@@ -245,7 +245,7 @@ class Trace:
         pad = 1024 - (len(traces[0]) % 1024)  # padding to power of 2, increases transform speed
         traces = np.pad(traces, [[0, 0], [0, pad]], mode='constant')
         trspec = np.fft.rfft(traces, axis=-1, norm='ortho')
-        trfreq = np.fft.rfftfreq(len(traces[0]), time[1] - time[0])
+        trfreq = np.fft.rfftfreq(len(traces[0]), np.median(np.diff(time)))
         return trfreq, trspec
 
     def stackfilter(self, time, trace_ref, trace_filt, window):

--- a/app/plot_app/plotting.py
+++ b/app/plot_app/plotting.py
@@ -828,9 +828,11 @@ class DataPlotSpec(DataPlot):
 
             data_set[timestamp_key] = self._cur_dataset.data[timestamp_key]
 
-            # calculate the sampling frequency
-            # (Note: logging dropouts are not taken into account here)
-            delta_t = ((data_set[timestamp_key][-1] - data_set[timestamp_key][0]) * 1.0e-6) / len(data_set[timestamp_key])
+            # calculate the sampling frequency using the median inter-sample interval
+            # to avoid bias from logging dropouts
+            dt_diff = np.diff(data_set[timestamp_key])
+            delta_t = np.median(dt_diff) * 1.0e-6
+            mean_delta_t = np.mean(dt_diff) * 1.0e-6
             if delta_t < 0.000001: # avoid division by zero
                 self._had_error = True
                 return
@@ -858,7 +860,8 @@ class DataPlotSpec(DataPlot):
 
             # offset = int(((1024/2.0)/250.0)*1e6)
             # scale time to microseconds and add start time as offset
-            time = time * 1.0e6 + self._cur_dataset.data[timestamp_key][0]
+            # stretch by mean/median to realign with actual elapsed time after dropout correction
+            time = time * (mean_delta_t / delta_t) * 1.0e6 + self._cur_dataset.data[timestamp_key][0]
 
             inner_image = 10 * np.log10(sum_psd)
             # Bokeh/JSON can't handle -inf.
@@ -945,9 +948,9 @@ class DataPlotFFT(DataPlot):
             data_set[timestamp_key] = self._cur_dataset.data[timestamp_key]
             data_len = len(data_set[timestamp_key])
 
-            # calculate the sampling frequency
-            # (Note: logging dropouts are not taken into account here)
-            delta_t = ((data_set[timestamp_key][-1] - data_set[timestamp_key][0]) * 1.0e-6) / data_len
+            # calculate the sampling frequency using the median inter-sample interval
+            # to avoid bias from logging dropouts
+            delta_t = np.median(np.diff(data_set[timestamp_key])) * 1.0e-6
             sampling_frequency = 1.0 / delta_t
 
             if sampling_frequency < 100 or sampling_frequency == float("inf"): # require min sampling freq


### PR DESCRIPTION
Using median of sampling rate instead of mean.

dt_median = median(diff(time))
instead of 
dt_mean = mean(diff(time))

Referring to [issue 339](https://github.com/PX4/flight_review/issues/339)

corrected in this PR
* FFT resistant to dropout
* Spectrogram resistant to dropout
* Spectrogram time axis scaled by dt_mean/dt_median to keep a correct time length