### PR TITLE
Add opt-in timeout to log loading to prevent worker hangs

### DIFF
--- a/app/config_default.ini
+++ b/app/config_default.ini
@@ -25,6 +25,12 @@ cesium_enable_bing_aerial = 1
 # available RAM and Log file size. Should be a power of 2.
 log_cache_size = 8
 
+# maximum seconds to spend loading/parsing a single log file before aborting.
+# Guards against a stalled storage backend (e.g. a hung S3 FUSE/NFS read)
+# freezing a worker indefinitely. 0 disables the timeout (default, unchanged
+# behavior). Only takes effect when load_ulog_file runs on the main thread.
+log_load_timeout = 0
+
 # Encryption key
 # Suggested location:../private_key/private_key.pem
 ulge_private_key =

--- a/app/plot_app/config.py
+++ b/app/plot_app/config.py
@@ -40,6 +40,7 @@ __MAPBOX_API_ACCESS_TOKEN = _conf.get('general', 'mapbox_api_access_token')
 __CESIUM_API_KEY = _conf.get('general', 'cesium_api_key')
 __CESIUM_ENABLE_BING_AERIAL = _conf.get('general', 'cesium_enable_bing_aerial')
 __LOG_CACHE_SIZE = int(_conf.get('general', 'log_cache_size'))
+__LOG_LOAD_TIMEOUT = int(_conf.get('general', 'log_load_timeout'))
 __DB_FILENAME_CUSTOM = _conf.get('general', 'db_filename')
 
 __STORAGE_PATH = _conf.get('general', 'storage_path')
@@ -170,6 +171,10 @@ def get_cesium_enable_bing_aerial():
 def get_log_cache_size():
     """ get maximum number of cached logs in RAM """
     return __LOG_CACHE_SIZE
+
+def get_log_load_timeout():
+    """ get maximum seconds to spend loading a single log (0 = disabled) """
+    return __LOG_LOAD_TIMEOUT
 
 def debug_print_timing():
     """ print timing information? """

--- a/app/plot_app/helper.py
+++ b/app/plot_app/helper.py
@@ -4,9 +4,12 @@ from timeit import default_timer as timer
 import time
 import re
 import os
+import signal
+import threading
 import traceback
 import sys
 from functools import lru_cache
+from contextlib import contextmanager
 from urllib.request import urlretrieve
 import xml.etree.ElementTree # airframe parsing
 import shutil
@@ -19,7 +22,7 @@ from scipy.interpolate import interp1d
 from config_tables import *
 from config import get_log_filepath, get_airframes_filename, get_airframes_url, \
                    get_parameters_filename, get_parameters_url, \
-                   get_log_cache_size, debug_print_timing, \
+                   get_log_cache_size, get_log_load_timeout, debug_print_timing, \
                    get_releases_filename
 
 from Crypto.Cipher import ChaCha20
@@ -290,6 +293,43 @@ class ULogException(Exception):
     """
     pass
 
+
+class ULogTimeoutException(ULogException):
+    """
+    Exception to indicate that loading a log took longer than the configured
+    timeout. This usually means the storage backend (e.g. an S3 FUSE/NFS mount)
+    stalled on a read. It is a subclass of ULogException so existing handlers
+    treat it as a (transient) load error.
+    """
+    pass
+
+
+@contextmanager
+def _log_load_timeout(seconds, file_name):
+    """ abort the wrapped block after `seconds` using SIGALRM.
+
+    A stalled read on a network/FUSE filesystem blocks in a C-level syscall, so
+    a thread-based timeout cannot interrupt it; SIGALRM can. SIGALRM is only
+    deliverable on the main thread, so if we are not on the main thread (e.g.
+    called from a thread-pool executor) the timeout silently no-ops and the
+    block runs without a deadline. A value of 0 also disables the timeout.
+    """
+    if seconds <= 0 or threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise ULogTimeoutException(
+            "Loading log %s timed out after %d s" % (file_name, seconds))
+
+    previous = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
 @lru_cache(maxsize=get_log_cache_size())
 def load_ulog_file(file_name):
     """ load an ULog file
@@ -319,9 +359,16 @@ def load_ulog_file(file_name):
                   'vehicle_thrust_setpoint', 'vehicle_torque_setpoint',
                   'failsafe_flags']
     try:
-        ulog = ULog(file_name, msg_filter, disable_str_exceptions=True)
+        with _log_load_timeout(get_log_load_timeout(), file_name):
+            ulog = ULog(file_name, msg_filter, disable_str_exceptions=True)
     except FileNotFoundError:
         print("Error: file %s not found" % file_name)
+        raise
+    except ULogTimeoutException:
+        # storage backend stalled - surface as-is (a ULogException subclass) so
+        # the worker recovers instead of hanging. Not cached (lru_cache only
+        # stores successful returns).
+        print("Error: loading file %s timed out" % file_name)
         raise
 
     # catch all other exceptions and turn them into an ULogException

--- a/app/plot_app/main.py
+++ b/app/plot_app/main.py
@@ -108,6 +108,10 @@ else:
         px4_ulog = PX4ULog(ulog)
         px4_ulog.add_roll_pitch_yaw()
 
+    except ULogTimeoutException:
+        error_message = ('The server timed out while reading this log - the '
+                         'storage backend may be busy. Please reload the page '
+                         'in a moment to try again.')
     except ULogException:
         error_message = ('A parsing error occured when trying to read the file - '
                          'the log is most likely corrupt.')

--- a/app/tornado_handlers/upload.py
+++ b/app/tornado_handlers/upload.py
@@ -22,7 +22,8 @@ from db_entry import DBVehicleData, DBData
 from config import get_db_connection, get_http_protocol, get_domain_name, \
     email_notifications_config, get_ulge_private_key_path
 from helper import get_total_flight_time, validate_url, get_log_filename, \
-    load_ulog_file, get_airframe_name, ULogException, decrypt_ulge_payload
+    load_ulog_file, get_airframe_name, ULogException, ULogTimeoutException, \
+    decrypt_ulge_payload
 from overview_generator import generate_overview_img_from_id
 
 
@@ -329,6 +330,15 @@ class UploadHandler(TornadoRequestHandlerBase):
 
             except CustomHTTPError:
                 raise
+
+            except ULogTimeoutException as e:
+                # transient: the storage backend stalled while reading the file,
+                # not a problem with the file itself. 503 signals retryable.
+                raise CustomHTTPError(
+                    503,
+                    'The server timed out while reading your file. Your upload '
+                    'was received but could not be processed right now - please '
+                    'try uploading again in a moment.') from e
 
             except ULogException as e:
                 raise CustomHTTPError(


### PR DESCRIPTION
A stalled storage read can currently freeze a worker indefinitely. `load_ulog_file()` parses a log with a synchronous, C-level `ULog()` read on the worker's main thread, with no deadline. When the storage backend behind `storage_path` stops answering a read (for us an S3 FUSE mount that briefly stalled), that call blocks forever, the worker stops serving every other request, and in production this took down all workers and the site until they were manually killed.

This adds an opt-in `general.log_load_timeout` config option (seconds, default `0` = disabled, so behavior is unchanged unless you set it) that wraps the parse in a `SIGALRM`-based wall-clock timeout. `SIGALRM` is used deliberately: a thread-based timeout cannot interrupt a read blocked in a FUSE/NFS syscall, but a signal can. The guard no-ops when not on the main thread (where `SIGALRM` is undeliverable), so it stays safe if the load is ever moved to a thread pool. On timeout it raises `ULogTimeoutException`, a subclass of `ULogException`, so existing handlers already treat it as a transient load error and the worker recovers instead of hanging.

Because a timeout is transient and not a problem with the file, the second commit gives it a distinct, retryable message instead of the generic "most likely corrupt" one. The upload handler returns HTTP 503 with a note that the upload was received but processing timed out and to try again; the plot page shows a "storage busy, reload to try again" message. The timeout exception is caught ahead of `ULogException` in both places since it's a subclass.

To arm it in production, set `log_load_timeout` to something like `60` in `config_user.ini`. Left at the default `0` it is a no-op.
