### PR TITLE
Don't fail the estimator plot on newer logs missing innovation_check_flags

### DIFF
--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -944,16 +944,25 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
         input_data = [
             ('Health Flags (vel, pos, hgt)', estimator_status['health_flags']),
             ('Timeout Flags (vel, pos, hgt)', estimator_status['timeout_flags']),
-            ('Velocity Check Bit', (estimator_status['innovation_check_flags'])&0x1),
-            ('Horizontal Position Check Bit', (estimator_status['innovation_check_flags']>>1)&1),
-            ('Vertical Position Check Bit', (estimator_status['innovation_check_flags']>>2)&1),
-            ('Mag X, Y, Z Check Bits', (estimator_status['innovation_check_flags']>>3)&0x7),
-            ('Yaw Check Bit', (estimator_status['innovation_check_flags']>>6)&1),
-            ('Airspeed Check Bit', (estimator_status['innovation_check_flags']>>7)&1),
-            ('Synthetic Sideslip Check Bit', (estimator_status['innovation_check_flags']>>8)&1),
-            ('Height to Ground Check Bit', (estimator_status['innovation_check_flags']>>9)&1),
-            ('Optical Flow X, Y Check Bits', (estimator_status['innovation_check_flags']>>10)&0x3),
             ]
+        # innovation_check_flags was removed from estimator_status in newer PX4
+        # versions (the checks moved to *_test_ratio / pre_flt_fail_innov_*
+        # fields). Only add these rows for older logs that still have the field,
+        # so newer logs still render the health/timeout flags above instead of
+        # skipping the whole plot.
+        if 'innovation_check_flags' in estimator_status:
+            innovation_check_flags = estimator_status['innovation_check_flags']
+            input_data += [
+                ('Velocity Check Bit', (innovation_check_flags)&0x1),
+                ('Horizontal Position Check Bit', (innovation_check_flags>>1)&1),
+                ('Vertical Position Check Bit', (innovation_check_flags>>2)&1),
+                ('Mag X, Y, Z Check Bits', (innovation_check_flags>>3)&0x7),
+                ('Yaw Check Bit', (innovation_check_flags>>6)&1),
+                ('Airspeed Check Bit', (innovation_check_flags>>7)&1),
+                ('Synthetic Sideslip Check Bit', (innovation_check_flags>>8)&1),
+                ('Height to Ground Check Bit', (innovation_check_flags>>9)&1),
+                ('Optical Flow X, Y Check Bits', (innovation_check_flags>>10)&0x3),
+                ]
         # filter: show only the flags that have non-zero samples
         for cur_label, cur_data in input_data:
             if np.amax(cur_data) > 0.1:


### PR DESCRIPTION
The "Estimator Flags" plot reads `estimator_status['innovation_check_flags']` unconditionally, but that field was removed from the `estimator_status` message in newer PX4 versions, where the innovation checks moved to the `*_test_ratio` and `pre_flt_fail_innov_*` fields. On every modern log this raises `KeyError`, which is caught and printed as "Error in estimator plot", and the entire plot is skipped, including the `health_flags` and `timeout_flags` rows that are still present in the message.

This guards the innovation_check_flags-derived rows behind a presence check, so older logs that still have the field render exactly as before, while newer logs without it still render the health and timeout flags rather than dropping the whole plot. The two always-present rows are kept unconditional, so the empty-plot fallback below still has data to reference.

A side benefit is that the per-log-view exception and its log noise go away, which on a busy server adds up across nearly every log that gets opened.

This does not attempt to remap the old check bits onto the newer `*_test_ratio` fields, since they are different representations and not a 1:1 mapping. Surfacing the newer innovation data for modern logs would be a separate enhancement.
