### PR TITLE
feat(plot): add Connected Devices section

### DIFF
--- a/app/plot_app/configured_plots.py
+++ b/app/plot_app/configured_plots.py
@@ -13,7 +13,7 @@ from helper import *
 from leaflet import ulog_to_polyline
 from plotting import *
 from plotted_tables import (
-    get_logged_messages, get_changed_parameters,
+    get_logged_messages, get_changed_parameters, get_connected_devices,
     get_info_table_html, get_heading_html, get_error_labels_html,
     get_hardfault_html, get_corrupt_log_html
     )
@@ -1102,6 +1102,11 @@ def generate_plots(ulog, px4_ulog, db_data, vehicle_data, link_to_3d_page,
 
     # changed parameters
     plots.append(get_changed_parameters(ulog, plot_width))
+
+    # connected devices
+    connected_devices = get_connected_devices(ulog, plot_width)
+    if connected_devices is not None:
+        plots.append(connected_devices)
 
 
 

--- a/app/plot_app/helper.py
+++ b/app/plot_app/helper.py
@@ -357,7 +357,7 @@ def load_ulog_file(file_name):
                   'ekf2_timestamps', 'manual_control_switches', 'event',
                   'vehicle_imu_status', 'actuator_motors', 'actuator_servos',
                   'vehicle_thrust_setpoint', 'vehicle_torque_setpoint',
-                  'failsafe_flags']
+                  'failsafe_flags', 'device_information']
     try:
         with _log_load_timeout(get_log_load_timeout(), file_name):
             ulog = ULog(file_name, msg_filter, disable_str_exceptions=True)

--- a/app/plot_app/plotted_tables.py
+++ b/app/plot_app/plotted_tables.py
@@ -581,3 +581,114 @@ def get_logged_messages(ulog, plot_width):
                            autosize_mode='none')
     div = Div(text="""<b>Logged Messages</b>""", width=int(plot_width/2))
     return column(div, data_table, width=plot_width)
+
+
+# device_information.device_type (matches MAVLink DEVICE_TYPE enum)
+_DEVICE_TYPES = {
+    0: 'Generic', 1: 'Airspeed', 2: 'ESC', 3: 'Servo', 4: 'GPS',
+    5: 'Magnetometer', 6: 'Parachute', 7: 'Rangefinder', 8: 'Winch',
+    9: 'Barometer', 10: 'Optical Flow', 11: 'Accelerometer', 12: 'Gyroscope',
+    13: 'Differential Pressure', 14: 'Battery', 15: 'Hygrometer',
+    }
+
+
+def _format_device_version(version):
+    """ DroneCAN firmware is 'major.minor.<vcs_commit>' with the commit logged in
+        decimal; render a commit-sized third field (> 0xffff) as a hex git hash. """
+    parts = version.split('.')
+    if len(parts) == 3 and parts[2].isdigit() and int(parts[2]) > 0xffff:
+        return '{:}.{:} ({:08x})'.format(parts[0], parts[1], int(parts[2]))
+    return version
+
+
+def _device_char_array(data, prefix, index, max_chars):
+    """ decode a pyulog char[N] field (stored as prefix[0], prefix[1], ... uint8
+        columns) into a printable string, stopping at the NUL terminator """
+    chars = []
+    for j in range(max_chars):
+        key = '{:}[{:}]'.format(prefix, j)
+        if key not in data:
+            break
+        char_val = int(data[key][index])
+        if char_val == 0:
+            break
+        if 32 <= char_val <= 126:
+            chars.append(chr(char_val))
+    return ''.join(chars).rstrip()
+
+
+def get_connected_devices(ulog, plot_width):
+    """
+    get a bokeh column object with a table of the devices reported via the
+    device_information topic, or None if the log contains no such data.
+    :param ulog: ULog object
+    """
+    device_datasets = [elem for elem in ulog.data_list
+                       if elem.name == 'device_information']
+    if not device_datasets:
+        return None
+
+    # device_information is published round-robin, so each device recurs across
+    # samples; dedupe on device identity rather than timestamp.
+    seen = set()
+    types = []
+    names = []
+    ids = []
+    firmwares = []
+    hardwares = []
+    serials = []
+
+    for dataset in device_datasets:
+        data = dataset.data
+        for i in range(len(data['timestamp'])):
+            device_id = int(data['device_id'][i])
+            device_type_id = int(data['device_type'][i])
+            device_type = _DEVICE_TYPES.get(
+                device_type_id, 'Unknown ({:})'.format(device_type_id))
+
+            name = _device_char_array(data, 'name', i, 80)
+
+            firmware = _device_char_array(data, 'firmware_version', i, 24)
+            hardware = _device_char_array(data, 'hardware_version', i, 24)
+            serial = _device_char_array(data, 'serial_number', i, 33)
+
+            key = (device_type, name, device_id, serial)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            types.append(device_type)
+            names.append(escape(name) if name else 'Unknown')
+            ids.append(str(device_id))
+            firmwares.append(escape(_format_device_version(firmware)))
+            hardwares.append(escape(hardware))
+            serials.append(escape(serial))
+
+    device_data = {
+        'types': types,
+        'names': names,
+        'ids': ids,
+        'firmwares': firmwares,
+        'hardwares': hardwares,
+        'serials': serials,
+        }
+    source = ColumnDataSource(device_data)
+    columns = [
+        TableColumn(field="types", title="Type",
+                    width=int(plot_width*0.13), sortable=False),
+        TableColumn(field="names", title="Name",
+                    width=int(plot_width*0.27), sortable=False),
+        TableColumn(field="ids", title="Device ID",
+                    width=int(plot_width*0.12), sortable=False),
+        TableColumn(field="firmwares", title="Firmware",
+                    width=int(plot_width*0.16), sortable=False),
+        TableColumn(field="hardwares", title="Hardware",
+                    width=int(plot_width*0.12), sortable=False),
+        TableColumn(field="serials", title="Serial",
+                    width=int(plot_width*0.20), sortable=False),
+        ]
+    data_table = DataTable(source=source, columns=columns, width=plot_width,
+                           height=300, sortable=False, selectable=False,
+                           autosize_mode='none')
+    div = Div(text="""<b>Connected Devices</b>""", width=int(plot_width/2))
+    return column(div, data_table, width=plot_width)


### PR DESCRIPTION
## Summary
Adds a **Connected Devices** table to the flight log review page, listing every device reported via the `device_information` ULog topic

<img width="1424" height="254" alt="image" src="https://github.com/user-attachments/assets/989e9cda-c98a-48fd-9413-79431c0c2c67" />

## Problem
Logs carry rich `device_information` for connected components, but Flight Review never surfaced it — there was no way to see which devices were attached, their firmware/serial, or whether the expected hardware was present. The topic was not even loaded.

## Solution
Parse `device_information` and render it as a Bokeh table next to the existing Parameters / Logged Messages tables. The topic is published round-robin, so entries are deduped on device identity (type, name, id, serial). `device_type` maps to a human-readable label; DroneCAN firmware strings (`major.minor.<vcs_commit>`) render the commit as a hex git hash. The section is hidden when a log has no `device_information`.