### PR TITLE
feat(plot): draw uploaded annotations on the plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ in `app/tornado_handlers/`.
 application can subscribe to. A topic must live in this list in order to be
 plotted.
 
+A log can optionally carry annotations: YAML files uploaded alongside it that
+mark intervals of the flight, shown in a table and drawn onto the plots they
+name. See [docs/annotations.md](docs/annotations.md) for the file format and the
+design.
+
 Tornado uses a single-threaded event loop. This means all operations should be
 non-blocking (see also http://www.tornadoweb.org/en/stable/guide/async.html).
 (This is currently not the case for sending emails).

--- a/app/plot_app/annotations.py
+++ b/app/plot_app/annotations.py
@@ -1,0 +1,373 @@
+""" validation and rendering of user-provided log annotations (see docs/annotations.md) """
+
+import json
+import re
+from html import escape
+
+import yaml
+from bokeh import events
+from bokeh.models import (BoxAnnotation, ColumnDataSource, CustomJS, HoverTool, Label, LabelSet,
+                          Range1d, Span)
+
+from config import colors8, plot_width
+
+_STORED_VERSION = 1 # of the JSON in Logs.Annotations
+_YAML_VERSION = 1 # highest 'version:' an uploaded file may declare
+
+# caps on upload-derived data: strings truncate, counts reject (see docs/annotations.md)
+_MAX_FILE_BYTES = 1024*1024
+_MAX_NAME_CHARS = 64 # name, category, graph
+_MAX_TEXT_CHARS = 200 # annotation, value
+_MAX_CATEGORIES = 50
+_MAX_INTERVALS = 1000
+_MAX_TIME_SECONDS = 30*24*3600
+_MAX_ROWS_PER_PLOT = 6 # the strip must not grow into the plot it annotates
+
+_PALETTE = [color for color in colors8 if color != '#000000'] # a filled band must read as a color
+_COLOR_RE = re.compile(r'^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,20})$')
+_TIME_RE = re.compile(r'^(?:(?:(\d+):)?(\d+):)?(\d+(?:\.\d+)?)$')
+
+# the strip is drawn in screen units, as plotting.py draws the VTOL strip
+_ROW_HEIGHT_PX = 10 # of the coloured band
+_ROW_SPACING_PX = 12 # from one row's bottom to the next
+_PLOT_CHROME_PX = 60 # by how much a figure's height exceeds its frame, as plotting.py assumes
+_VALUE_LINE_HEIGHT_PX = 11
+_VALUE_CHAR_WIDTH_PX = 5.3 # of an 8pt character, near enough to keep value text off its neighbour
+_MAX_VALUE_LINES = 3 # value text stacks upward, and must not climb into the plot
+_RIGHT_ALIGN_AT = 0.75 # of the x axis: past here, value text must extend leftwards to fit
+
+_LABEL_STYLE = {'text_font_size': '8pt', 'text_baseline': 'bottom',
+                'background_fill_color': '#ffffff', 'background_fill_alpha': 0.7}
+# a hover target must be a glyph, and a glyph needs data units: this range makes the frame 0 to 1
+_HOVER_Y_RANGE = 'annotations'
+# pairs and not html, so that upload-derived text is inserted by bokeh as text and not as markup
+_TOOLTIPS = [('', '@row'), ('Time', '@when'), ('Note', '@note')]
+
+
+def _text(value, limit):
+    """ a yaml scalar as a stripped, utf-8 safe string of at most limit characters, or '' for
+        anything else (str() of an aliased collection can be enormous) """
+    if value is None or isinstance(value, (dict, list, tuple, set)):
+        return ''
+    return str(value).strip().encode('utf-8', 'replace').decode('utf-8')[:limit]
+
+
+def _time(value):
+    """ an annotation time in us on the boot clock, the same value the x axis labels """
+    # no sign, exponent, inf or nan matches, so the bounded sum below cannot overflow
+    text = _text(value, _MAX_NAME_CHARS)
+    match = _TIME_RE.match(text)
+    if not match:
+        raise ValueError('invalid time: {} (expected [h:]mm:ss)'.format(
+            text or type(value).__name__))
+    seconds = 3600*int(match[1] or 0)+60*int(match[2] or 0)+float(match[3])
+    if seconds > _MAX_TIME_SECONDS:
+        raise ValueError('time is beyond {} days: {}'.format(_MAX_TIME_SECONDS//86400, text))
+    return int(round(seconds*1e6))
+
+
+def _time_str(timestamp):
+    """ inverse of _time, formatted as the x axis labels it """
+    h, rest = divmod(int(timestamp//1000000), 3600)
+    m, s = divmod(rest, 60)
+    return '{:d}:{:02d}:{:02d}'.format(h, m, s) if h > 0 else '{:d}:{:02d}'.format(m, s)
+
+
+def _when(interval):
+    """ an interval's time, as both the table and the tooltip show it """
+    if interval['end'] is None:
+        return _time_str(interval['start'])
+    return _time_str(interval['start'])+' to '+_time_str(interval['end'])
+
+
+def _note(interval):
+    """ an interval's free text, the annotation followed by the value """
+    return ' '.join(text for text in (interval['text'], interval['value']) if text)
+
+
+def _color(value, fallback):
+    """ a color that is safe to put in a style attribute, or fallback if unset """
+    color = _text(value, _MAX_NAME_CHARS)
+    if not color:
+        return fallback
+    if not _COLOR_RE.match(color):
+        raise ValueError('invalid color: {}'.format(color))
+    return color
+
+
+def _interval(interval, where):
+    if not isinstance(interval, dict) or 'start' not in interval:
+        raise ValueError('{}: each interval needs a "start"'.format(where))
+    start = _time(interval['start'])
+    end = _time(interval['end']) if interval.get('end') is not None else None
+    if end is not None and end < start:
+        raise ValueError('{}: interval ends before it starts'.format(where))
+    return {'start': start, 'end': end,
+            'text': _text(interval.get('annotation'), _MAX_TEXT_CHARS),
+            'value': _text(interval.get('value'), _MAX_TEXT_CHARS)}
+
+
+def _category(entry, source_name, source_color, index):
+    if not isinstance(entry, dict):
+        raise ValueError('{}: each annotation must be a mapping'.format(source_name))
+    category = _text(entry.get('category'), _MAX_NAME_CHARS)
+    if not category:
+        raise ValueError('{}: an annotation is missing "category"'.format(source_name))
+    where = '{}/{}'.format(source_name, category)
+    graph = _text(entry.get('graph'), _MAX_NAME_CHARS)
+    if not graph:
+        raise ValueError('{}: missing "graph"'.format(where))
+    intervals = entry.get('intervals')
+    if not isinstance(intervals, list) or not intervals:
+        raise ValueError('{}: "intervals" must be a non-empty list'.format(where))
+    return {'category': category, 'graph': graph,
+            'color': _color(entry.get('color'), source_color or _PALETTE[index%len(_PALETTE)]),
+            'intervals': [_interval(interval, where) for interval in intervals]}
+
+
+def _validate(document):
+    """ one parsed file, normalized. The ValueError message is shown to the uploader """
+    if isinstance(document, dict): # the versioned form; a bare list of sources is version 1
+        version = document.get('version', _YAML_VERSION)
+        if isinstance(version, bool) or not isinstance(version, int) \
+                or not 1 <= version <= _YAML_VERSION:
+            raise ValueError('unsupported annotations version: {} (this server reads 1 to {})'
+                             .format(_text(version, _MAX_NAME_CHARS), _YAML_VERSION))
+        document = document.get('sources')
+    if not isinstance(document, list):
+        raise ValueError('expected a list of annotation sources at the top level')
+    sources = []
+    for source in document:
+        if not isinstance(source, dict):
+            raise ValueError('each annotation source must be a mapping with a "name"')
+        name = _text(source.get('name'), _MAX_NAME_CHARS)
+        if not name:
+            raise ValueError('an annotation source is missing "name"')
+        entries = source.get('annotations')
+        if not isinstance(entries, list) or not entries:
+            raise ValueError('{}: "annotations" must be a non-empty list'.format(name))
+        color = _color(source.get('color'), None)
+        sources.append({'name': name,
+                        'annotations': [_category(entry, name, color, i)
+                                        for i, entry in enumerate(entries)]})
+    return sources
+
+
+def _merge(documents):
+    """ validated files as one list, deduplicated on (source, category, graph): last wins """
+    sources = {}
+    for document in documents:
+        for source in document:
+            categories = sources.setdefault(source['name'], {})
+            for category in source['annotations']:
+                categories[(category['category'], category['graph'])] = category
+    merged = [{'name': name, 'annotations': list(categories.values())}
+              for name, categories in sources.items()]
+
+    # counted after deduplication, so re-uploading a corrected file does not creep to the limit
+    count = sum(len(source['annotations']) for source in merged)
+    if count > _MAX_CATEGORIES:
+        raise ValueError('too many categories: {} (limit {})'.format(count, _MAX_CATEGORIES))
+    count = sum(len(category['intervals']) for _, category in _walk(merged))
+    if count > _MAX_INTERVALS:
+        raise ValueError('too many intervals: {} (limit {})'.format(count, _MAX_INTERVALS))
+    return merged
+
+
+def _walk(sources):
+    """ iterate over (source name, category) """
+    for source in sources:
+        for category in source['annotations']:
+            yield source['name'], category
+
+
+def _plot_index(jinja_plots):
+    """ {lowercase title or fragment: plot}, the two ways an annotation's "graph" can name one
+        of the plots this log actually rendered """
+    index = {}
+    for plot in jinja_plots or []:
+        if isinstance(plot, dict) and plot.get('title') and plot.get('fragment'):
+            index[plot['title'].lower()] = index[plot['fragment'].lower()] = plot
+    return index
+
+
+def _label(text, color, bottom):
+    """ a row's label, pinned to the left edge of the frame """
+    return Label(x=4, x_units='screen', y=bottom+1, y_units='screen', text=text,
+                 text_color=color, padding=1, **_LABEL_STYLE)
+
+
+def _draw_all(plots, rows):
+    """ group the rows by the plot they name, and draw each plot's strip """
+    figures = {figure.ref['id']: figure for figure in plots if hasattr(figure, 'ref')}
+    by_figure = {}
+    for name, category, plot in rows:
+        if plot is not None and plot['model_id'] in figures:
+            by_figure.setdefault(plot['model_id'], []).append((name, category))
+    for model_id, figure_rows in by_figure.items():
+        _draw(figures[model_id], figure_rows)
+
+
+def _source(rows):
+    """ rows of values as the columns a ColumnDataSource is given """
+    return ColumnDataSource({name: [row[name] for row in rows] for name in rows[0]})
+
+
+def _strip_bottom(figure):
+    """ where the strip starts: clear of plotting.py's VTOL strip, the only other screen box """
+    strips = [box.top for box in figure.center if isinstance(box, BoxAnnotation)
+              and box.top_units == 'screen' and box.top is not None]
+    return max(strips)+_ROW_SPACING_PX-_ROW_HEIGHT_PX if strips else 0
+
+
+def _value_rows(figure, values, bottom):
+    """ a row's value text, on as many lines as it takes not to overlap itself, right aligned
+        near the right edge, where bokeh would otherwise run it off the plot """
+    start, end = figure.x_range.start, figure.x_range.end
+    # a frequency axis reads as nan, leaving no extent to lay text out along
+    extent = end-start if None not in (start, end) and end > start else 0
+    line_ends = []
+    rows = []
+    for x, text, color in sorted(values):
+        align = 'right' if extent and x > start+_RIGHT_ALIGN_AT*extent else 'left'
+        width = len(text)*_VALUE_CHAR_WIDTH_PX*extent/(figure.width or plot_width)
+        left = x-width if align == 'right' else x
+        line = next((i for i, edge in enumerate(line_ends) if edge <= left), len(line_ends))
+        line = min(line, _MAX_VALUE_LINES-1)
+        line_ends[line:line+1] = [left+width]
+        rows.append({'x': x, 'y': bottom+1+line*_VALUE_LINE_HEIGHT_PX,
+                     'text': text, 'color': color, 'align': align})
+    return rows
+
+
+def _draw(figure, rows):
+    """ draw one plot's rows: a labelled strip per category, a dashed line per instant """
+    bottom = _strip_bottom(figure)
+    frame = max((figure.height or 0)-_PLOT_CHROME_PX, _PLOT_CHROME_PX)
+    bands, marks, texts = [], [], []
+    for name, category in rows[:_MAX_ROWS_PER_PLOT]:
+        color = category['color']
+        row = '{}: {}'.format(name, category['category'])
+        values = []
+        for interval in category['intervals']:
+            where = {'row': row, 'when': _when(interval), 'note': _note(interval)}
+            if interval['end'] is None: # an instant: a zero-width box draws nothing
+                figure.add_layout(Span(location=interval['start'], dimension='height',
+                                       line_color=color, line_dash='dashed', line_alpha=0.8))
+                marks.append({'x': interval['start'], 'y': (bottom+_ROW_HEIGHT_PX/2)/frame,
+                              'color': color, **where})
+                if interval['value']:
+                    values.append((interval['start'], interval['value'], color))
+            else:
+                figure.add_layout(BoxAnnotation(
+                    left=interval['start'], right=interval['end'], bottom=bottom,
+                    top=bottom+_ROW_HEIGHT_PX, bottom_units='screen', top_units='screen',
+                    fill_color=color, fill_alpha=0.55, line_color=None,
+                    movable='none', resizable='none'))
+                bands.append({'left': interval['start'], 'right': interval['end'],
+                              'bottom': bottom/frame, 'top': (bottom+_ROW_SPACING_PX)/frame,
+                              **where})
+        figure.add_layout(_label(row, color, bottom))
+        texts += _value_rows(figure, values, bottom)
+        bottom += _ROW_SPACING_PX
+    _hover(figure, bands, marks)
+    if texts:
+        _reveal(figure, texts)
+
+
+def _hover(figure, bands, marks):
+    """ hover targets: a HoverTool takes neither a BoxAnnotation nor a Span, so a band gets an
+        invisible glyph of its own, and an instant a marker, easier to point at than a line """
+    renderers = []
+    if bands:
+        renderers.append(figure.quad(
+            left='left', right='right', bottom='bottom', top='top', y_range_name=_HOVER_Y_RANGE,
+            source=_source(bands), fill_alpha=0, line_alpha=0))
+    if marks:
+        renderers.append(figure.scatter(
+            x='x', y='y', y_range_name=_HOVER_Y_RANGE, source=_source(marks),
+            marker='inverted_triangle', size=7, fill_color='color', line_color=None))
+    if renderers:
+        figure.extra_y_ranges = dict(figure.extra_y_ranges, **{_HOVER_Y_RANGE: Range1d(0, 1)})
+        figure.add_tools(HoverTool(renderers=renderers, tooltips=_TOOLTIPS))
+
+
+def _reveal(figure, texts):
+    """ value text, hidden until the mouse enters the plot, as plotting.py hides flight modes """
+    labels = LabelSet(x='x', y='y', y_units='screen', text='text', text_color='color',
+                      text_align='align', source=_source(texts), visible=False, **_LABEL_STYLE)
+    figure.add_layout(labels)
+    callback = CustomJS(args={'labels': labels},
+                        code='labels.visible = cb_obj.event_name == "mouseenter";')
+    figure.js_on_event(events.MouseEnter, callback)
+    figure.js_on_event(events.MouseLeave, callback)
+
+
+def _section(body):
+    """ a card above the plots, as plotted_tables builds the corrupt-log and hardfault warnings """
+    return ('<div class="card mb-3"><div class="card-header">Annotations</div>'
+            '{}</div>'.format(body))
+
+
+def _table_html(rows):
+    """ the annotations section shown above the plots, or '' if there is nothing to show """
+    html = []
+    for name, category, plot in rows:
+        for interval in category['intervals']:
+            when = escape(_when(interval))
+            if plot is not None:
+                # main.js adds the Nav-* anchors once bokeh has rendered, navigate() waits
+                when = '<a href="javascript:navigate(\'{}\');">{}</a>'.format(
+                    escape(plot['fragment'], quote=True), when)
+            html.append('<tr><td>{}</td><td>{}</td><td>{}</td><td class="text-muted">{}</td></tr>'
+                        .format(escape(name), escape(category['category']), when,
+                                escape(_note(interval))))
+    if not html:
+        return ''
+    # the table scrolls rather than pushing the plots down; bootstrap has no max-height utility
+    return _section('<div class="card-body p-0" style="max-height: 200px; overflow: auto;">'
+                    '<table class="table table-sm mb-0"><thead><tr><th>Annotation</th>'
+                    '<th>Category</th><th>Time</th><th>Note</th></tr></thead><tbody>{}</tbody>'
+                    '</table></div>'.format(''.join(html)))
+
+
+def from_upload(parts):
+    """ the uploaded annotation files as JSON to store, or '' if there are none, raising
+        ValueError with a message for the uploader if one does not validate """
+    documents = []
+    try:
+        for part in parts:
+            if part.get_size() > _MAX_FILE_BYTES:
+                raise ValueError('file is too large')
+            if part.get_size() > 0: # an empty file input still posts a part
+                documents.append(_validate(yaml.safe_load(part.get_payload().decode('utf-8'))))
+        if not documents:
+            return ''
+        return json.dumps({'v': _STORED_VERSION, 'sources': _merge(documents)})
+    except ValueError:
+        raise # already phrased for the uploader
+    except RecursionError as error: # yaml parses nested flow collections recursively
+        raise ValueError('file is too deeply nested') from error
+    except Exception as error:
+        raise ValueError(_text(error, _MAX_TEXT_CHARS) or type(error).__name__) from error
+
+
+def render(stored, plots, jinja_plots):
+    """ draw a log's annotations onto plots (in place) and return the table html, or a notice
+        if the stored value cannot be used (never raises: the plots matter more) """
+    if not stored:
+        return ''
+    try:
+        document = json.loads(stored)
+        if document['v'] != _STORED_VERSION:
+            raise ValueError('stored version {} is not {}'.format(document['v'], _STORED_VERSION))
+        index = _plot_index(jinja_plots)
+        rows = [(name, category, index.get(category['graph'].lower()))
+                for name, category in _walk(document['sources'])]
+        html = _table_html(rows) # before drawing, so a bad row leaves the plots untouched
+        _draw_all(plots, rows)
+        return html
+    except Exception as error:
+        print('annotations: not rendering annotations:', error)
+        return _section('<div class="card-body">This log has annotations, but they could not be '
+                        'shown. See the server log for details.</div>')

--- a/app/plot_app/db_entry.py
+++ b/app/plot_app/db_entry.py
@@ -21,6 +21,7 @@ class DBData:
         self.video_url = ''
         self.error_labels = []
         self.source = ''
+        self.annotations = '' # stored JSON, see annotations.py
 
         super().__init__()
 

--- a/app/plot_app/main.py
+++ b/app/plot_app/main.py
@@ -18,6 +18,7 @@ from db_entry import *
 from configured_plots import generate_plots
 from pid_analysis_plots import get_pid_analysis_plots
 from statistics_plots import StatisticsPlots
+import annotations
 
 #pylint: disable=invalid-name, redefined-outer-name
 
@@ -132,7 +133,7 @@ else:
             con = get_db_connection()
             cur = con.cursor()
             cur.execute('select Description, Feedback, Type, WindSpeed, Rating, VideoUrl, '
-                        'ErrorLabels from Logs where Id = ?', [log_id])
+                        'ErrorLabels, Annotations from Logs where Id = ?', [log_id])
             db_tuple = cur.fetchone()
             if db_tuple is not None:
                 db_data.description = db_tuple[0]
@@ -144,6 +145,7 @@ else:
                 db_data.error_labels = sorted(
                     [int(x) for x in db_tuple[6].split(',') if len(x) > 0]) \
                     if db_tuple[6] else []
+                db_data.annotations = db_tuple[7]
 
             # vehicle data
             if 'sys_uuid' in ulog.msg_info_dict:
@@ -232,6 +234,10 @@ else:
             try:
                 plots = generate_plots(ulog, px4_ulog, db_data, vehicle_data,
                                        link_to_3d_page, link_to_pid_analysis_page)
+
+                # after generate_plots, so the annotations see the titles the plots really got
+                curdoc().template_variables['annotations_html'] = annotations.render(
+                    db_data.annotations, plots, curdoc().template_variables.get('plots'))
 
                 title = 'Flight Review - '+px4_ulog.get_mav_type()
 

--- a/app/plot_app/templates/index.html
+++ b/app/plot_app/templates/index.html
@@ -18,6 +18,7 @@
 {{ info_table_html }}
 {{ corrupt_log_html }}
 {{ error_labels_html }}
+{{ annotations_html if annotations_html }}
 
 {% if has_position_data %}
 

--- a/app/plot_app/templates/upload.html
+++ b/app/plot_app/templates/upload.html
@@ -81,6 +81,17 @@
 					</td>
 				</tr>
 				<tr>
+					<td class="left">Annotations (optional):</td>
+					<td>
+						<div class="input-group flex-row-reverse">
+							<input type="file" name="annotations" id="annotations"
+									class="form-control" multiple accept=".yaml,.yml">
+						</div>
+						<small class="text-muted">YAML files marking intervals of the flight,
+							drawn on the plots they name.</small>
+					</td>
+				</tr>
+				<tr>
 					<td id="feedback" colspan="2">
 					</td>
 				</tr>

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,6 +4,7 @@ jupyter
 pyfftw
 pylint
 pyulog>=1.1
+pyyaml
 requests
 scipy>=1.8.1
 simplekml

--- a/app/setup_db.py
+++ b/app/setup_db.py
@@ -60,6 +60,7 @@ with con:
                 "ErrorLabels TEXT, " # the type of error (if any) that occurred during flight
                 "Public INT, " # if 1 this log can be publicly listed
                 "Token TEXT, " # Security token (currently used to delete the entry)
+                "Annotations TEXT, " # user-provided annotations (see plot_app/annotations.py)
                 "CONSTRAINT Id_PK PRIMARY KEY (Id))")
     else:
         # try to upgrade
@@ -91,6 +92,9 @@ with con:
         if not 'Token' in column_names:
             print('Adding column Token')
             cur.execute("ALTER TABLE Logs ADD COLUMN Token TEXT DEFAULT ''")
+        if not 'Annotations' in column_names:
+            print('Adding column Annotations')
+            cur.execute("ALTER TABLE Logs ADD COLUMN Annotations TEXT DEFAULT ''")
 
 
     # LogsGenerated table (information from the log file, for faster access)

--- a/app/tornado_handlers/upload.py
+++ b/app/tornado_handlers/upload.py
@@ -25,6 +25,7 @@ from helper import get_total_flight_time, validate_url, get_log_filename, \
     load_ulog_file, get_airframe_name, ULogException, ULogTimeoutException, \
     decrypt_ulge_payload
 from overview_generator import generate_overview_img_from_id
+import annotations
 
 
 #pylint: disable=relative-beyond-top-level
@@ -181,6 +182,14 @@ class UploadHandler(TornadoRequestHandlerBase):
                         if form_data['public'].decode("utf-8") == 'true':
                             is_public = 1
 
+                # validated before anything is written. Read as parts: get_values() caps at 10 KB
+                try:
+                    annotations_json = annotations.from_upload(
+                        self.multipart_streamer.get_parts_by_name('annotations'))
+                except ValueError as error:
+                    raise CustomHTTPError(
+                        400, 'Invalid annotations file: {}'.format(error)) from error
+
                 file_obj = self.multipart_streamer.get_parts_by_name('filearg')[0]
                 upload_file_name = file_obj.get_filename()
 
@@ -241,12 +250,13 @@ class UploadHandler(TornadoRequestHandlerBase):
                         'insert into Logs (Id, Title, Description, '
                         'OriginalFilename, Date, AllowForAnalysis, Obfuscated, '
                         'Source, Email, WindSpeed, Rating, Feedback, Type, '
-                        'videoUrl, ErrorLabels, Public, Token) values '
-                        '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        'videoUrl, ErrorLabels, Public, Token, Annotations) values '
+                        '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                         [log_id, title, description, upload_file_name,
                          datetime.datetime.now(), allow_for_analysis,
                          obfuscated, source, stored_email, wind_speed, rating,
-                         feedback, upload_type, video_url, error_labels, is_public, token])
+                         feedback, upload_type, video_url, error_labels, is_public, token,
+                         annotations_json])
 
                     if ulog is not None:
                         vehicle_data = update_vehicle_db_entry(cur, ulog, log_id, vehicle_name)

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,0 +1,253 @@
+# Annotations
+
+Flight Review plots what the vehicle recorded. It has no way to show what somebody *knows* about
+a stretch of that flight - ground truth from a test sheet, a reviewer's note, the verdict of an
+external analyzer. Today that knowledge lives in a spreadsheet next to the browser, and matching
+it against a plot is done by eye.
+
+Annotations close that gap. One or more YAML files are uploaded alongside the log; the intervals
+they describe are listed in a compact table above the plots, and drawn as coloured bars along the
+bottom edge of the plot each one names.
+
+Everything is optional at every step: a log uploaded without annotations renders exactly as it
+does today.
+
+## The file
+
+```yaml
+version: 1                    # optional; a bare list of sources is version 1
+sources:
+  - name: Ground Truth        # who is saying this
+    color: "#b3261e"          # optional default for this source's categories
+    annotations:
+      - category: takeoff_wobble
+        graph: Roll Angle     # the plot's title, or its 'Nav-...' fragment id
+        color: "#a06000"      # optional, overrides the source colour
+        intervals:
+          - start: "01:23"
+            end: "01:40"
+            annotation: "oscillation"       # optional free text
+          - start: "02:10"                  # no end -> vertical dotted line
+            value: "roll rate 12.4 deg/s"   # optional free text drawn at the line
+```
+
+The top level may also be the bare list of sources - `- name: Ground Truth` … - which is what a
+hand-written file usually looks like. Both parse to the same thing.
+
+| Field | Where | Meaning |
+|---|---|---|
+| `version` | document | Schema the file was written against. Optional, defaults to 1. |
+| `name` | source | Shown in the table's *annotation* column and on every bar the source draws. Required. |
+| `color` | source, category | `#rgb`, `#rrggbb` or a CSS colour name. Optional; categories otherwise cycle `config.colors8`, the palette the plots themselves use, less its black entry. |
+| `category` | annotation | What this is. One category is one bar on one plot. Required. |
+| `graph` | annotation | Which plot to draw on: its title (`Roll Angle`) or its anchor (`Nav-Roll-Angle`). Required. |
+| `start`, `end` | interval | `mm:ss`, `h:mm:ss`, `mm:ss.mmm`, or seconds as a number. `end` is optional. |
+| `annotation` | interval | Free text, shown in the table. |
+| `value` | interval | Free text, drawn beside the dotted line of a point interval. |
+
+`value` is a **string**, not a number, because a Flight Review plot carries several series: a bare
+`12.4` cannot say what it measured, and `roll rate 12.4 deg/s` can.
+
+### Times are the boot clock
+
+`start` and `end` are read the way the x-axis is labelled. `plotting.py` formats a tick by
+dividing the raw microsecond timestamp by 1e6 with **no** subtraction of `ulog.start_timestamp`,
+so `01:23` on the axis is 83 seconds since the board booted, not since the log began. An
+annotation time is therefore whatever you read off the axis, and the conversion is a
+multiplication.
+
+This is also why the feature never touches the ULog: no message names, no field names, no
+timestamps are read to place an annotation. A change to the log format cannot invalidate one.
+
+## Where annotations are stored
+
+In `Logs.Annotations`, a `TEXT` column holding normalized, versioned JSON
+(`{"v": 1, "sources": [...]}`).
+
+The alternative was a sidecar file beside the `.ulg`, as the KML and preview image are stored. The
+column wins on the part nobody enjoys maintaining:
+
+* **Deletion is free.** `edit_entry.py` and `prune_old_logs.py` already `DELETE FROM Logs`. A
+  sidecar needs its own `os.unlink` in both, and the precedent is not encouraging - `prune_old_logs.py`
+  does not clean up `.kml` files today, so that path already leaks.
+* **Backup is free.** `backup_db.py` dumps the database. A sidecar is invisible to it.
+* **Writing is atomic.** The annotations go in on the same `INSERT` as the log entry, inside the
+  same transaction, so there is no window where a file exists with no row pointing at it.
+* **Nothing new to configure.** No directory, no `config_default.ini` key, no `makedirs` in
+  `setup_db.py`.
+
+Serializing structure into a `TEXT` column is the existing idiom here: `ErrorLabels` and
+`FlightModeDurations` both do it. The column is added to `Logs` - the table that already holds
+everything the *uploader* supplies - and not to `LogsGenerated`, which is a cache of what the ULog
+itself says. Existing databases pick it up through the same
+`PRAGMA table_info` → `ALTER TABLE … DEFAULT ''` upgrade branch that added the nine columns before
+it, so `python setup_db.py` is the whole migration.
+
+## Two schema versions
+
+`_STORED_VERSION` versions the JSON in the column; `_YAML_VERSION` is the highest `version:` an
+uploaded file may declare. They are separate because they move for different reasons: the stored
+shape can change for something the YAML never sees (a new computed field), and a file's schema can
+change without the storage doing so.
+
+The version belongs *in the file* because the file outlives this server. Annotations get generated
+by external tools, committed to repositories, and re-uploaded months later; the only party that
+can say which schema a file was written against is the file. A file declaring a newer version is
+refused by name - the uploader can then go and find a server that understands it, which a
+half-rendered page would never tell them.
+
+## Validate loudly, render quietly
+
+The two halves of the feature have opposite failure policies, on purpose.
+
+**Upload rejects.** A malformed file fails the upload with a 400 naming the problem
+(`Invalid annotations file: Ground Truth/takeoff_wobble: interval ends before it starts`), while
+the user is still looking at the form and can fix it. Validation runs *before* the `.ulg` is
+written, so a rejected upload leaves nothing behind.
+
+`from_upload` guarantees that by wrapping its whole body the way `helper.load_ulog_file` does:
+`except ValueError: raise` passes through the messages written for the uploader, and one
+`except Exception` converts everything else into a `ValueError` too. Enumerating the exceptions a
+hostile YAML file can provoke does not work - the first attempt missed `RecursionError` from the
+parser and `OverflowError` from `.inf` - and each one missed is a 500 for something the uploader
+could have fixed. Like `load_ulog_file`, this attributes any failure inside the parse boundary to
+the input; that is the right default when the boundary's only job is to read a user's file.
+
+**Rendering never fails.** `render` swallows every exception. By the time a page is being drawn,
+the alternative to "no annotations" is "no plots", and nobody's annotation is worth someone else's
+log page. A log whose column is *empty* renders with no annotations section at all; a log whose
+column holds something this server cannot use - corrupt JSON, or a `_STORED_VERSION` it does not
+know - still gets the section, carrying one line saying so, with the reason on the server's stdout.
+The distinction matters: "this log has no annotations" and "this log's annotations are not being
+shown" look identical otherwise.
+
+That notice is an inline Bootstrap card - the same shape `plotted_tables.get_corrupt_log_html` uses
+- not a toast. Flight Review has no toast anywhere: it reports through a full error page
+(`CustomHTTPError`), a Bokeh `Div` in place of the plots, a Bootstrap `alert`/`card` block in the
+page body (`error_labels_html`, `hardfault_html`, `corrupt_log_html`), or a hidden `<div>` revealed
+by JS on the upload form. Bootstrap 5 ships the toast component in the bundled CSS/JS, but nothing
+here uses it, and a message that vanishes on a timer is the wrong shape for a page state that is
+still true after it fades.
+
+Note that a *database* failure is invisible by design, and not specific to annotations:
+`main.py` wraps the whole `select` in a bare `except` that prints and leaves `db_data` at its
+defaults, so a failed read looks exactly like a log with no description, no rating, and no
+annotations. Annotations behave like every other column rather than inventing a second policy.
+
+Between those sits the one case that is neither: a `graph` that no longer matches any plot - after
+an upstream rename, or because this log didn't record that topic. That annotation is still listed
+in the table, just without a link and without shading. Plot names are resolved late, against the
+`plots` variable `configured_plots` hands the template, and are never stored as truth.
+
+## Limits
+
+Annotations arrive on an upload, so they are not trusted input.
+
+| Limit | Value | On breach |
+|---|---|---|
+| File size | 1 MB per file | Upload rejected |
+| `name`, `category`, `graph` | 64 characters | Truncated |
+| `annotation`, `value` | 200 characters | Truncated |
+| `start`, `end` | 0 to 30 days | Upload rejected |
+| Categories per log | 50 | Upload rejected |
+| Intervals per log | 1000 | Upload rejected |
+| Rows drawn on one plot | 6 | Extra rows listed in the table only |
+
+Free text truncates because an over-long note is cosmetic and losing the upload over it is not
+proportionate. Counts reject because silently dropping annotations would leave the uploader
+believing the log carries data it does not. Counts are checked after deduplication, so
+re-uploading a corrected file cannot creep towards the limit.
+
+The time bound is not about display, it is about arithmetic: YAML's `.inf`, `1e400` and integers
+too large for a float all reach `_time`, and without it they raise `OverflowError` - a 500 for
+something the uploader could have fixed. For the same reason a value that is a list or a mapping is
+never passed to `str()`: YAML aliases can make a small file describe an enormous structure, and
+`str()` on one of those builds it. Free text is also stripped of lone surrogates, which YAML
+accepts but UTF-8 cannot encode - one in a `name` would otherwise pass validation, reach the
+database, and then break the whole log page at the point Tornado writes it, well outside anything
+`render` can catch.
+
+Duplicates - the same `(source, category, graph)` uploaded twice - are resolved by a linear scan,
+last definition wins, keeping the position of the first. Re-uploading a corrected file replaces a
+category rather than doubling it.
+
+## How it is drawn
+
+The bar is a `BoxAnnotation` with its **x in data units and its y in screen units**, which is
+`plot_flight_modes_background`'s own trick for the VTOL strip: a fixed-height bar spanning a time
+range, whatever the y-range does, sitting below the flight-mode background rather than tinting it.
+Rows stack upward from the bottom edge, starting above the VTOL strip on the plots that have one -
+the strip's own `top` is read off the figure rather than assumed, so upstream is free to change
+`vtol_state_height` without the two overlapping. A category's intervals share one row, which is
+what lets a single bar have disjoint sections.
+
+The row is labelled `Ground Truth: takeoff_wobble` - source and category - pinned to the left edge
+of the frame in screen units, so it holds its place under pan and zoom the way the row it names
+does.
+
+An interval with no `end` is an instant. A zero-width box renders as nothing at all, so those
+become a dashed `Span` instead, plus a small marker where the line crosses the row.
+
+### What the mouse reveals
+
+At rest the strip shows only geometry - bands, instant lines and row labels. Per-interval text is
+drawn but hidden, and arrives two ways when the mouse comes near:
+
+* **A tooltip** on the band or the instant marker, carrying source, category, time and note - the
+  same fields as the table row.
+* **The `value` text**, revealed for the whole plot on `MouseEnter` and hidden again on
+  `MouseLeave`. This is `plot_flight_modes_background`'s own trick for flight mode names
+  (`plotting.py:161-183`): a `LabelSet` with `visible = False` and a two-line `CustomJS`.
+
+Tooltips need a `DataRenderer`, and `BoxAnnotation`, `Span` and `Label` are none of them, so the
+visible band cannot itself be hovered. Rather than redraw the band as a glyph - which would give up
+the screen-unit trick above, and with it the exact row heights and the VTOL clearance - an
+*invisible* `quad` is laid over it purely as a hover target, and the instants get a visible marker
+because a one-pixel dashed line is hard to point at. Both are scoped into one `HoverTool` per plot,
+as `plotting.py:51` scopes the dropout hover; nothing in `plot_app` uses `renderers='auto'`, so
+there is no ambient hover to capture them. `tooltips` is given as a list of pairs rather than an
+HTML string, so Bokeh inserts the uploaded strings as text and not as markup.
+
+A glyph cannot use screen units, so those targets live on an `extra_y_ranges` entry fixed at
+`Range1d(0, 1)` and their pixel offsets are divided by the frame height - which Python does not
+know, so it uses `plot.height - 60`, the same allowance `plotting.py:137` makes for its own labels.
+The target is a full row *spacing* tall rather than a row height, so it still covers the band if that
+estimate is off by a few pixels. Being invisible, an error there costs hover accuracy, never
+appearance.
+
+The **row label is not itself a hover target**, for the same `DataRenderer` reason: a data-space
+glyph cannot be pinned to the frame edge. Hovering the band it names gives the same text.
+
+Two things Bokeh will not do for a `Label`, both handled in Python before rendering:
+
+* **It does not flip at the frame edge.** A label in the right quarter of the x range is given
+  `text_align='right'` so it extends leftwards instead of off the plot.
+* **It does not declutter.** Labels sharing a row are packed onto as many lines as they need, up to
+  three, using an approximate character width. Without this, two instants a few seconds apart on a
+  three-minute flight draw on top of each other.
+
+The table itself is a Bootstrap `card` + `table table-sm`, styled entirely by classes from the
+bundled theme, as every other block Flight Review builds in Python is. No stylesheet is added: the
+only rule Bootstrap has no utility for is the scroll cap that keeps the section from pushing the
+plots down, and that is one inline `style` on one `<div>` - the same way `upload.html` and
+`plotted_tables.py` express their one-off rules. Custom CSS worth reusing belongs in
+`static/css/main.css`, and this feature has none.
+
+## Not included
+
+* Attaching or editing annotations on a log that is already uploaded. They ride along with the
+  upload, because that is when the log id is assigned.
+* Serving the annotations back for download.
+* Any interpretation of what an annotation means - this feature displays them, it does not judge
+  the flight.
+
+## Where the code is
+
+| File | Role |
+|---|---|
+| `app/plot_app/annotations.py` | All of it, behind two entry points: `from_upload` and `render`. |
+| `app/tornado_handlers/upload.py` | Passes the `annotations` parts to `from_upload`, stores the result on the log row. |
+| `app/plot_app/main.py` | Calls `render` after `generate_plots`. |
+| `app/plot_app/templates/upload.html` | The file input. |
+| `app/plot_app/templates/index.html` | Where the table is placed. |
+| `app/setup_db.py` | The `Logs.Annotations` column and its upgrade branch. |


### PR DESCRIPTION
## Summary
Adds an optional **Annotations** field to the upload form: YAML files marking intervals of a flight,
listed in a table above the plots and drawn onto the plots they name.

<img width="769" height="334" alt="annotated-plot" src="https://github.com/user-attachments/assets/c4001c6e-eb1c-4249-965a-7093cc61f529" />

## Problem
A log is usually reviewed against something already known about the flight - a test sheet, an
operator's notes, the verdict of an external analyzer. That context lives outside Flight Review
today, so the reviewer reads a time off one document and hunts for it on the plot. There is no way
to put "this is the interval in question" on the page next to the data.

## Solution
`plot_app/annotations.py` validates the uploaded YAML and renders it. A file declares one or more
sources, each with a colour and a set of categories; a category names a `graph` (the plot's title,
or a `Nav-...` fragment id) and carries intervals with a `start`, an optional `end`, and optional
`annotation` / `value` text. Times are read the way the x-axis is labelled, so an annotation time is
whatever you read off the plot.

- **Upload** - the files are parsed before anything is written; a bad file fails the upload with a
  400 rather than storing a half-annotated log. The result is stored as JSON in a new
  `Logs.Annotations` column, which `setup_db.py` adds to an existing database on its next run.
- **Rendering** - runs after `generate_plots`, so a `graph` is matched against the titles the plots
  actually got. Bands are drawn in a screen-unit strip below the data, the same way `plotting.py`
  draws the VTOL strip, so they never occlude the trace; `value` text is revealed on hover, capped
  at three stacked lines. Unmatched categories still appear in the table.
- **Limits** - upload-derived strings truncate and counts reject (1 MB per file, 1000 intervals,
  6 rows per plot). Every field is escaped on the way into the table, and hover tooltips are passed
  to Bokeh as field pairs rather than as an HTML string, so uploaded text is inserted as text.

A log uploaded without annotations renders exactly as it does today; the section and the strip are
simply absent.

<img width="747" height="257" alt="ss5" src="https://github.com/user-attachments/assets/38f82420-dfbe-4c7c-b196-2d857ae565fc" />
*The table above the plots.*

<img width="517" height="491" alt="annotations-upload" src="https://github.com/user-attachments/assets/37740b98-cf86-4a2b-80ac-870ffdf33b4f" />
*The one addition to the upload page.*

Adds `pyyaml` to `app/requirements.txt`. Format and design notes in `docs/annotations.md` - that is a
new directory, since at 253 lines the spec would more than double the root README; happy to move or
trim it if you would rather it lived somewhere else.